### PR TITLE
Document pluggable annotation pipeline and agent infrastructure

### DIFF
--- a/.cursor/rules/schematic-core.mdc
+++ b/.cursor/rules/schematic-core.mdc
@@ -1,7 +1,7 @@
-# Schematic Core Rules
-
-> Cursor: copy to `.cursor/rules/schematic-core.mdc` with `alwaysApply: true` frontmatter. See [README.md](./README.md).
-
+---
+description: Schematic core design rules — pluggable handlers, no hard-coded features
+alwaysApply: true
+---
 Schematic is a pluggable Prisma annotation pipeline. Read `AGENTS.md` and `docs/status.md` before coding.
 
 ## Must follow

--- a/.cursor/rules/schematic-handlers.mdc
+++ b/.cursor/rules/schematic-handlers.mdc
@@ -1,0 +1,32 @@
+---
+description: Rules for handler definitions and example handlers
+globs: examples/**/*.ts,**/schematic.handlers.ts
+alwaysApply: false
+---
+Handlers are user-defined. Core only orchestrates. See `docs/handlers.md`.
+
+## AnnotationDefinition contract
+
+```typescript
+interface AnnotationDefinition {
+  type: string;           // matches @schematic.{type}(...)
+  schema: z.ZodType;      // validates parsed args + injected model/field
+  dropPriority?: number;  // higher = dropped first on removal
+  handlers: {
+    up: (input, ctx) => ({ upSql, downSql });
+    mutate?: (old, next, ctx) => ({ upSql, downSql });
+  };
+}
+```
+
+## Handler rules
+
+- Return **both** `upSql` and `downSql` from `up()` — downSql is persisted in state
+- Use idempotent SQL: `IF NOT EXISTS` / `IF EXISTS`
+- Derive deterministic object names from model + input
+- Use `ctx.databaseProvider` for provider-specific syntax
+- Do not put handler logic in `src/state/extractor.ts` or `src/generator/`
+
+## Examples belong in `examples/handlers/`
+
+Not in `src/schemas/`. The closed `src/schemas/index.ts` registry is legacy — remove when implementing registry.

--- a/.cursor/rules/schematic-state.mdc
+++ b/.cursor/rules/schematic-state.mdc
@@ -1,0 +1,46 @@
+---
+description: State, diffing, and migration SQL rules
+globs: src/state/**/*.ts,src/migrations/**/*.ts,src/cli/**/*.ts
+alwaysApply: false
+---
+See `docs/plan.md` for data flow. See `docs/status.md` for what exists today.
+
+## State shape (target)
+
+```typescript
+interface State {
+  version: '1';
+  generatedAt: string;
+  schemaHash: string;
+  features: StateFeature[];  // NOT indexes[]
+}
+
+interface StateFeature {
+  id: string;
+  type: string;
+  model: string;
+  input: Record<string, unknown>;
+  upSql: string;
+  downSql: string;  // stored at creation, never recomputed on removal
+  createdAt: string;
+}
+```
+
+## Diff rules
+
+- Match features by stable `id`
+- **Added** → emit `upSql`
+- **Removed** → emit stored `downSql` from baseline (git HEAD)
+- **Changed** → emit `mutate()` or old `downSql` + new `upSql`
+
+## Enhance SQL order
+
+1. Drops: `dropPriority` desc, then `createdAt` desc
+2. Creates: stable order by `id`
+3. Mutations: down then up per feature
+
+## Do not
+
+- Bucket features into hard-coded arrays (`indexes`, `partialIndexes`, etc.)
+- Recompute `downSql` on removal
+- Use disk state as enhance baseline

--- a/.cursor/skills/schematic/SKILL.md
+++ b/.cursor/skills/schematic/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: schematic
+description: >-
+  Implement or extend Schematic (pluggable Prisma annotation pipeline). Use when
+  working on Schematic core, state/diff/migrations, handler registry, CLI
+  enhance/validate, or when the user asks to implement the next phase from
+  docs/status.md.
+---
+
+# Schematic Development
+
+## Start here
+
+1. Read [AGENTS.md](../../AGENTS.md)
+2. Read [docs/status.md](../../docs/status.md) — **implementation truth**; do not trust roadmap/README alone
+3. Read [docs/plan.md](../../docs/plan.md) for architecture invariants
+
+## Non-negotiables
+
+- No hard-coded annotation types in `src/`
+- Annotations from DMMF `documentation` only
+- Persist `upSql` + `downSql` in state; enhance baselines git HEAD
+- Update `docs/status.md` + affected docs in the same PR as code
+
+## Implementing the next phase
+
+1. Open `docs/status.md` and pick an unchecked item from "Not implemented"
+2. Implement the smallest vertical slice with tests
+3. Update `docs/status.md` (move item to Implemented)
+4. Update other docs if behavior/architecture/user-facing API changed (see AGENTS.md table)
+5. Run `pnpm test && pnpm typecheck && pnpm lint`
+
+## Key modules (target layout)
+
+| Module | Role |
+| ------ | ---- |
+| `src/registry/` | Load user `AnnotationDefinition[]` |
+| `src/state/extractor.ts` | Scan DMMF docs, match handlers |
+| `src/state/builder.ts` | Build state, preserve stored SQL by id |
+| `src/state/comparator.ts` | Diff by feature id |
+| `src/migrations/` | Append ordered SQL to Prisma migrations |
+| `src/cli/` | `enhance`, `validate` |
+
+## Testing focus
+
+- Parser edge cases (`annotation.utils.ts`)
+- Diff/reversal: removed feature emits stored `downSql` without handler
+- Builder preserves SQL for unchanged ids
+- Delete ordering: `dropPriority`, then reverse `createdAt`
+
+## References
+
+- Handler API: [docs/handlers.md](../../docs/handlers.md)
+- Architecture: [docs/architecture.md](../../docs/architecture.md)
+- Example handlers: `examples/handlers/` (when present)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What changed and why -->
+
+## Checklist
+
+- [ ] `pnpm test` passes
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm lint` passes
+- [ ] Tests updated for behavior changes
+- [ ] [docs/status.md](../docs/status.md) updated (if implementation changed)
+- [ ] Other docs updated per [AGENTS.md](../AGENTS.md#documentation-maintenance) (plan, architecture, handlers, README, agent-rules — as applicable)
+- [ ] No hard-coded annotation types added to core (`src/`)
+- [ ] Roadmap items marked complete only if code + status.md reflect it
+
+## Agent / doc notes
+
+<!-- Optional: link to design doc, note intentional doc lag, etc. -->

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ generated/
 .env
 .env.local
 
+# Claude Code local overrides (personal, not shared)
+CLAUDE.local.md
+
 # IDE
 .vscode/
 .idea/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,92 @@
+# Agent Guide — Schematic
+
+This file orients AI agents (Cursor, Claude, etc.) working in this repo. Read it first.
+
+## What this project is
+
+Schematic is a **Prisma generator + CLI** that lets users define custom database annotations via **Zod schemas and handlers**. Core orchestrates extraction, validation, state, diffing, and migration SQL. **Nothing feature-specific is hard-coded in core.**
+
+Target workflow:
+
+```bash
+prisma migrate dev --create-only --name my_change
+schematic enhance          # diff vs git HEAD, append SQL
+prisma migrate dev         # apply + prisma generate updates state
+```
+
+## Documentation map
+
+| Doc | Purpose |
+| --- | ------- |
+| [docs/plan.md](docs/plan.md) | Canonical design reference (start here for architecture) |
+| [docs/architecture.md](docs/architecture.md) | Module layout, data flows, invariants |
+| [docs/handlers.md](docs/handlers.md) | How users author handlers |
+| [docs/status.md](docs/status.md) | **What is implemented vs documented** |
+| [docs/roadmap.md](docs/roadmap.md) | Completed phases and future work |
+| [docs/future.md](docs/future.md) | Explicitly out-of-scope / later items |
+| [README.md](README.md) | User-facing overview |
+
+## Non-negotiable design rules
+
+1. **No hard-coded annotation types in core** — partial indexes, GIN indexes, FK auto-index, etc. belong in `examples/handlers/` or user projects, not `src/`.
+2. **Annotations come from DMMF `documentation`** — doc comments (`///`) on models and fields. Handlers do not define where annotations are found.
+3. **Persist `downSql` in state at creation** — reversals use stored SQL from the state file, not re-invoked handlers. This allows undo even after a handler is removed.
+4. **`schematic enhance` baselines against git HEAD** — not the post-`prisma generate` disk state. See [docs/plan.md](docs/plan.md).
+5. **Functional, small files** — pure functions, composition over inheritance. See [docs/architecture.md](docs/architecture.md).
+6. **Minimal scope** — match existing conventions; don't add unrelated code, tests, or docs unless requested.
+
+## Key types (target architecture)
+
+```typescript
+// User-facing (registry/types.ts)
+interface AnnotationDefinition<TSchema extends z.ZodType> {
+  type: string;
+  schema: TSchema;
+  dropPriority?: number;
+  handlers: {
+    up: (input, ctx) => { upSql: string; downSql: string };
+    mutate?: (old, next, ctx) => SqlPair;
+  };
+}
+
+// State (state.types.ts)
+interface StateFeature {
+  id: string;       // stable hash(type + model + field? + input)
+  type: string;
+  model: string;
+  input: Record<string, unknown>;
+  upSql: string;
+  downSql: string;  // persisted at creation, used for reversal
+  createdAt: string;
+}
+```
+
+## Before making changes
+
+1. Read [docs/status.md](docs/status.md) — docs may describe target state; code may lag.
+2. Check `.cursor/rules/` for file-specific constraints.
+3. Prefer extending the registry pipeline over adding special cases in extractor/builder.
+4. Do not reintroduce closed registries like `src/schemas/index.ts` with hard-coded types.
+
+## Common mistakes to avoid
+
+- Adding `partialIndex`, `ginIndex`, etc. as built-in core logic
+- Re-calling `handler.up()` for unchanged features (preserve stored SQL by stable `id`)
+- Using disk state as enhance baseline instead of git HEAD
+- Scanning for annotations outside DMMF `documentation` without an explicit design change
+- Updating README/roadmap to claim features are done before code implements them (update `docs/status.md` instead)
+
+## Testing expectations
+
+- Unit test pure functions (parser, comparator, hash, builder)
+- Test reversal: removal emits stored `downSql` even when handler is absent
+- Test delete ordering: `dropPriority` then reverse `createdAt`
+
+## Branch context
+
+- `docs/pluggable-annotation-pipeline` — documentation describes target architecture
+- Implementation work should align docs/code or update `docs/status.md` when intentionally partial
+
+## Agent rules (Cursor)
+
+Rule sources live in [`docs/agent-rules/`](docs/agent-rules/). Copy to `.cursor/rules/*.mdc` per that README, or switch to Agent mode to install them automatically.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,20 @@
 # Agent Guide — Schematic
 
-This file orients AI agents (Cursor, Claude, etc.) working in this repo. Read it first.
+This file orients AI agents (Cursor, Claude, etc.) working in this repo. **Read it first.**
 
-## What this project is
+---
 
-Schematic is a **Prisma generator + CLI** that lets users define custom database annotations via **Zod schemas and handlers**. Core orchestrates extraction, validation, state, diffing, and migration SQL. **Nothing feature-specific is hard-coded in core.**
+## Project overview
 
-Target workflow:
+**Schematic** is a Prisma generator and CLI that lets users define custom database annotations via Zod schemas and handlers. Core orchestrates extraction, validation, state tracking, diffing, and migration SQL. Users bring the features; core brings the pipeline.
+
+**Prisma owns:** tables, columns, relations, basic indexes, migration history.
+
+**Schematic owns:** reading `@schematic.*` doc comments from DMMF, validating via user handlers, persisting desired state, diffing, and appending SQL to Prisma migrations.
+
+**Users own:** annotation types, Zod schemas, and SQL generation logic (`upSql` / `downSql`).
+
+Target dev workflow:
 
 ```bash
 prisma migrate dev --create-only --name my_change
@@ -14,31 +22,172 @@ schematic enhance          # diff vs git HEAD, append SQL
 prisma migrate dev         # apply + prisma generate updates state
 ```
 
+User-facing docs: [README.md](README.md). Design spec: [docs/plan.md](docs/plan.md).
+
+---
+
+## Philosophy
+
+These principles apply to **all** work in this repo — code, docs, and tests.
+
+### Pluggable over prescriptive
+
+Nothing feature-specific belongs in core. Partial indexes, GIN indexes, FK auto-indexing, check constraints — all are handler examples or user code, not built-in branches in `src/`.
+
+### Functional and composable
+
+This tool is a pipeline of transformations (schema → state → diff → SQL). Prefer small pure functions, clear inputs/outputs, and composition over inheritance or deep class hierarchies.
+
+### Minimal scope
+
+Use the simplest correct diff. Do not add unrelated code, refactors, tests, or docs unless requested or clearly required by the change. Match existing naming, imports, and file structure.
+
+### State is the source of truth for reversal
+
+When a feature is created, persist both `upSql` and `downSql` in the state file. Removals emit stored `downSql` — even if the handler is later deleted. Do not recompute reversal SQL at drop time.
+
+### Docs must not lie about implementation
+
+[docs/status.md](docs/status.md) tracks what is actually built. README and roadmap may describe target architecture. Before claiming a feature is done, update code **and** status.
+
+### Docs stay in sync with code
+
+Documentation updates belong in the **same PR** as code changes. See "Documentation maintenance" under Development practices for which files to update when.
+
+---
+
+## Development practices
+
+### Commands
+
+```bash
+pnpm install
+pnpm build
+pnpm test              # run all tests
+pnpm test:coverage     # coverage report
+pnpm typecheck
+pnpm lint
+pnpm format:check
+```
+
+### Testing
+
+**Test thoroughly.** There is no fixed coverage percentage enforced in CI today, but every change should be tested appropriately:
+
+- **Update tests when you change behavior** — if you modify a module, update its tests in the same PR
+- **Pure functions get unit tests** — parser, hash, comparator, builder, config extraction
+- **Test behavior, not implementation** — especially diff/reversal paths (removed feature emits stored `downSql`; handler absent still reverses)
+- **Avoid trivial tests** — don't assert the obvious; do cover edge cases and regressions
+- **New modules ship with tests** — colocate as `*.test.ts` next to source (existing convention)
+
+Critical paths that always need tests when touched:
+
+| Area | Why |
+| ---- | --- |
+| `annotation.utils.ts` | Parsing is easy to break with edge-case strings |
+| `state/comparator.ts` | Wrong diff = wrong migrations |
+| `state/builder.ts` | Must preserve stored SQL for unchanged ids |
+| `registry/loader.ts` | User handler loading must fail clearly |
+
+Run `pnpm test` before considering work complete.
+
+### Documentation maintenance
+
+**Keep docs in sync with code.** Documentation drift is how agents and humans build the wrong thing. Update docs in the **same PR** as code changes — not in a follow-up.
+
+#### Always update (when relevant to your change)
+
+| Doc | Update when |
+| --- | ----------- |
+| [docs/status.md](docs/status.md) | Any implementation change — move items between implemented / not implemented |
+| Tests | Behavior changes (see Testing above) |
+| [AGENTS.md](AGENTS.md) | Project philosophy, dev practices, or agent workflow changes |
+| [docs/agent-rules/](docs/agent-rules/) | Agent/Cursor rules change — keep in sync with AGENTS.md |
+
+#### Update when the change affects them
+
+| Doc | Update when |
+| --- | ----------- |
+| [docs/plan.md](docs/plan.md) | Architecture, invariants, or data flow change |
+| [docs/architecture.md](docs/architecture.md) | Module layout, file paths, or responsibilities change |
+| [docs/handlers.md](docs/handlers.md) | Public handler API or authoring contract changes |
+| [README.md](README.md) | User-facing setup, config options, CLI, or workflow changes |
+| [docs/roadmap.md](docs/roadmap.md) | A phased feature is **actually shipped** (code + status.md first) |
+| [docs/future.md](docs/future.md) | Scope moves in or out of the project |
+| [examples/handlers/](examples/handlers/) | Example handler API or patterns change |
+
+#### Usually do not update
+
+- **README / roadmap** for internal refactors with no user-visible change
+- **plan.md / architecture.md** for bug fixes that don't change design
+- **All docs** on every PR — only what your change touches
+
+#### Consistency rules
+
+1. **`docs/status.md` is the implementation truth** — if code exists, status must reflect it; if status claims done, code must exist
+2. **Roadmap checkboxes follow status.md** — never mark complete in roadmap alone
+3. **Agent docs follow human docs** — if workflow or architecture changes, update AGENTS.md and agent-rules together
+4. **Don't document unimplemented behavior as current** — use "planned" in future.md or leave out of README until shipped
+5. **Minimal doc diffs** — same as code; don't rewrite unrelated sections
+
+### Code quality
+
+- TypeScript strict — run `pnpm typecheck`
+- ESLint + Prettier — match existing style (`pnpm lint`, `pnpm format:check`)
+- `@/` path aliases — follow existing imports
+- One concern per file — see [docs/architecture.md](docs/architecture.md)
+
+### Before opening a PR
+
+1. `pnpm test && pnpm typecheck && pnpm lint`
+2. Tests updated for behavior changes
+3. [docs/status.md](docs/status.md) updated if implementation changed
+4. Other docs updated per the table above (plan, architecture, README, agent-rules — as applicable)
+5. Do not mark roadmap items complete without code + status update
+6. Keep diffs focused — no drive-by refactors or doc rewrites
+
+### Commits
+
+Only commit when asked. Follow existing commit message style (concise, explains why).
+
+---
+
 ## Documentation map
 
-| Doc | Purpose |
-| --- | ------- |
-| [docs/plan.md](docs/plan.md) | Canonical design reference (start here for architecture) |
-| [docs/architecture.md](docs/architecture.md) | Module layout, data flows, invariants |
-| [docs/handlers.md](docs/handlers.md) | How users author handlers |
-| [docs/status.md](docs/status.md) | **What is implemented vs documented** |
+| Doc | When to read |
+| --- | ------------ |
+| [docs/status.md](docs/status.md) | **Always** — what's implemented vs documented |
+| [docs/plan.md](docs/plan.md) | Architecture decisions, data flow, invariants |
+| [docs/architecture.md](docs/architecture.md) | Module layout and responsibilities |
+| [docs/handlers.md](docs/handlers.md) | Authoring user-facing handlers |
 | [docs/roadmap.md](docs/roadmap.md) | Completed phases and future work |
-| [docs/future.md](docs/future.md) | Explicitly out-of-scope / later items |
-| [README.md](README.md) | User-facing overview |
+| [docs/future.md](docs/future.md) | Explicitly deferred items |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Human contributor setup and workflow |
+| [CLAUDE.md](CLAUDE.md) | Claude Code entry point (imports this file + docs) |
+| [docs/agent-rules/](docs/agent-rules/) | Cursor rule sources (installed to `.cursor/rules/`) |
 
-## Non-negotiable design rules
+---
 
-1. **No hard-coded annotation types in core** — partial indexes, GIN indexes, FK auto-index, etc. belong in `examples/handlers/` or user projects, not `src/`.
-2. **Annotations come from DMMF `documentation`** — doc comments (`///`) on models and fields. Handlers do not define where annotations are found.
-3. **Persist `downSql` in state at creation** — reversals use stored SQL from the state file, not re-invoked handlers. This allows undo even after a handler is removed.
-4. **`schematic enhance` baselines against git HEAD** — not the post-`prisma generate` disk state. See [docs/plan.md](docs/plan.md).
-5. **Functional, small files** — pure functions, composition over inheritance. See [docs/architecture.md](docs/architecture.md).
-6. **Minimal scope** — match existing conventions; don't add unrelated code, tests, or docs unless requested.
+## Schematic-specific rules
 
-## Key types (target architecture)
+These are domain constraints agents must not violate. Details in [docs/plan.md](docs/plan.md).
+
+1. **Annotations come from DMMF `documentation`** — `///` doc comments on models and fields. Handlers do not define where annotations are found.
+2. **`schematic enhance` baselines git HEAD state** — not post-`prisma generate` disk state.
+3. **Preserve stored SQL for unchanged feature ids** — do not re-call `handler.up()` on unchanged entries.
+4. **No closed registries** — do not reintroduce hard-coded type lists like `src/schemas/index.ts`.
+5. **Fail fast** on unknown annotation types when no handler is registered.
+
+### Common mistakes
+
+- Hard-coding `partialIndex`, `ginIndex`, etc. in core
+- Bucketing state into `indexes[]`, `partialIndexes[]`, etc. instead of `features[]`
+- Using disk state as enhance baseline
+- Claiming features done in docs without updating `docs/status.md`
+
+### Key types (target)
 
 ```typescript
-// User-facing (registry/types.ts)
 interface AnnotationDefinition<TSchema extends z.ZodType> {
   type: string;
   schema: TSchema;
@@ -49,44 +198,35 @@ interface AnnotationDefinition<TSchema extends z.ZodType> {
   };
 }
 
-// State (state.types.ts)
 interface StateFeature {
-  id: string;       // stable hash(type + model + field? + input)
+  id: string;
   type: string;
   model: string;
   input: Record<string, unknown>;
   upSql: string;
-  downSql: string;  // persisted at creation, used for reversal
+  downSql: string;
   createdAt: string;
 }
 ```
 
-## Before making changes
+---
 
-1. Read [docs/status.md](docs/status.md) — docs may describe target state; code may lag.
-2. Check `.cursor/rules/` for file-specific constraints.
-3. Prefer extending the registry pipeline over adding special cases in extractor/builder.
-4. Do not reintroduce closed registries like `src/schemas/index.ts` with hard-coded types.
+## Cursor rules
 
-## Common mistakes to avoid
+Installed rules: [.cursor/rules/](.cursor/rules/) (auto-injected in Cursor).
 
-- Adding `partialIndex`, `ginIndex`, etc. as built-in core logic
-- Re-calling `handler.up()` for unchanged features (preserve stored SQL by stable `id`)
-- Using disk state as enhance baseline instead of git HEAD
-- Scanning for annotations outside DMMF `documentation` without an explicit design change
-- Updating README/roadmap to claim features are done before code implements them (update `docs/status.md` instead)
+Sources (keep in sync when editing): [docs/agent-rules/](docs/agent-rules/).
 
-## Testing expectations
+| Rule | Scope |
+| ---- | ----- |
+| `schematic-core.mdc` | Always — design non-negotiables |
+| `schematic-handlers.mdc` | Handlers and examples |
+| `schematic-state.mdc` | State, migrations, CLI |
 
-- Unit test pure functions (parser, comparator, hash, builder)
-- Test reversal: removal emits stored `downSql` even when handler is absent
-- Test delete ordering: `dropPriority` then reverse `createdAt`
+Project skill: [.cursor/skills/schematic/SKILL.md](.cursor/skills/schematic/SKILL.md) — use when implementing phases from `docs/status.md`.
 
-## Branch context
+---
 
-- `docs/pluggable-annotation-pipeline` — documentation describes target architecture
-- Implementation work should align docs/code or update `docs/status.md` when intentionally partial
+## Branch note
 
-## Agent rules (Cursor)
-
-Rule sources live in [`docs/agent-rules/`](docs/agent-rules/). Copy to `.cursor/rules/*.mdc` per that README, or switch to Agent mode to install them automatically.
+`docs/pluggable-annotation-pipeline` — documentation describes target architecture; verify against [docs/status.md](docs/status.md) before assuming code exists.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# Schematic — Claude Code
+
+Read @AGENTS.md first. It is the canonical source for project overview, philosophy, dev practices, documentation upkeep, and Schematic-specific rules.
+
+## Before coding
+
+1. @docs/status.md — what is implemented vs documented (do not assume docs match code)
+2. @docs/plan.md — target architecture and invariants
+
+## Quick reminders
+
+- Pluggable handlers only — no feature-specific logic in `src/`
+- Annotations from DMMF `documentation` (doc comments), not custom locate functions
+- Persist `downSql` in state at creation; `enhance` baselines git HEAD
+- Update docs in the same PR as code (see AGENTS.md documentation maintenance table)
+
+## Commands
+
+```bash
+pnpm test && pnpm typecheck && pnpm lint
+pnpm build
+```
+
+## Deep references
+
+- Handler authoring: @docs/handlers.md
+- Module layout: @docs/architecture.md
+- Cursor rules: `.cursor/rules/` (also sourced from `docs/agent-rules/`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing to Schematic
+
+Thanks for contributing. This guide covers setup, workflow, and expectations for humans and AI agents.
+
+## AI agents
+
+**Start with [AGENTS.md](AGENTS.md).** It is the canonical guide for philosophy, dev practices, documentation upkeep, and Schematic-specific rules.
+
+- Claude Code: [CLAUDE.md](CLAUDE.md) points to the same sources
+- Cursor: rules in [.cursor/rules/](.cursor/rules/) (sources in [docs/agent-rules/](docs/agent-rules/))
+
+## Setup
+
+```bash
+git clone <repo-url>
+cd schematic
+pnpm install
+pnpm build
+pnpm test
+```
+
+Requires Node.js >= 18.
+
+## Development workflow
+
+```bash
+pnpm dev          # watch build
+pnpm test         # run tests
+pnpm test:watch   # watch mode
+pnpm typecheck
+pnpm lint
+pnpm format:check
+```
+
+## Making changes
+
+1. Read [docs/status.md](docs/status.md) — know what's implemented vs documented
+2. Read [docs/plan.md](docs/plan.md) — understand target architecture
+3. Keep diffs focused — minimal scope, match existing conventions
+4. Test thoroughly — update tests when behavior changes
+5. Update docs in the **same PR** as code (see AGENTS.md documentation maintenance table)
+
+### Documentation
+
+| Priority | File | When |
+| -------- | ---- | ---- |
+| Always | `docs/status.md` | Implementation changes |
+| As needed | `docs/plan.md`, `architecture.md`, `handlers.md`, `README.md` | When your change affects them |
+| As needed | `AGENTS.md`, `docs/agent-rules/` | Philosophy or agent workflow changes |
+
+## Pull requests
+
+Use the PR template checklist. Ensure:
+
+- Tests pass
+- Docs reflect code changes
+- No feature-specific logic hard-coded in core
+
+## Architecture principles
+
+- **Pluggable handlers** — users define Zod schemas + SQL handlers
+- **Core orchestrates** — extract, validate, state, diff, append migrations
+- **Stored reversal SQL** — `downSql` persisted in state at creation
+
+See [docs/architecture.md](docs/architecture.md) for details.
+
+## Questions
+
+Open an issue or refer to [docs/roadmap.md](docs/roadmap.md) and [docs/future.md](docs/future.md).

--- a/README.md
+++ b/README.md
@@ -1,93 +1,71 @@
 # Schematic
 
-> **Enhance Prisma migrations with database-specific features**
+> **Extend Prisma migrations with custom database features — you define the annotations and handlers**
 
-Schematic extends Prisma with powerful database features that aren't natively supported—like partial indexes, auto-indexed foreign keys, and provider-specific optimizations—all while using Prisma's standard workflow.
+Schematic is a Prisma generator and CLI that lets you declare database enhancements Prisma doesn't natively support — partial indexes, expression indexes, check constraints, and more — via doc-comment annotations in your schema. **Nothing is hard-coded in core.** You provide a Zod schema and handler for each annotation type you need.
 
 ---
 
 ## The Problem
 
-Prisma is great, but it doesn't support many database-specific features:
+Prisma handles tables, columns, relations, and basic indexes well. It does not support many provider-specific optimizations:
 
-❌ **No partial indexes** (PostgreSQL `WHERE` clauses)  
-❌ **No expression indexes** (full-text search, computed values)  
-❌ **Missing FK indexes on PostgreSQL** (causes slow joins and deletes)  
-❌ **No provider-specific index types** (GIN, GIST, spatial indexes)  
-❌ **Limited check constraints**
+- Partial indexes (`WHERE` clauses)
+- Expression indexes (full-text search, computed values)
+- Provider-specific index types (GIN, GIST, etc.)
+- Complex check constraints
 
-You're left writing raw SQL migrations by hand or missing out on critical optimizations.
+You're left hand-writing raw SQL in migration files and keeping it in sync with your schema manually.
 
 ## The Solution
 
-Schematic analyzes your Prisma schema and automatically enhances your migrations with these features:
+Define annotation handlers once, annotate your schema, and let Schematic manage state and migration SQL:
 
 ```prisma
-// schema.prisma
+generator schematic {
+  provider          = "schematic"
+  handlers          = "./schematic.handlers.ts"
+  stateFilePath     = "./.schematic-state.json"
+  annotationPrefix  = "schematic"
+}
+
+/// @schematic.partialIndex(columns: ["status"], where: "status = 'active'")
 model Post {
-  id       Int     @id
-  authorId Int
-  author   User    @relation(fields: [authorId], references: [id])
-  // ↑ Schematic auto-adds index on authorId (PostgreSQL needs this!)
-
-  status   String
-  /// @schematic.partialIndex(columns: ["status"], where: "status = 'active'")
-  // ↑ Custom partial index for better performance
-
-  title    String
-  /// @schematic.ginIndex(columns: ["title"], expression: "to_tsvector('english', title)")
-  // ↑ Full-text search (PostgreSQL GIN index)
+  id     Int    @id @default(autoincrement())
+  status String
 }
 ```
 
-**Schematic automatically generates:**
-
-```sql
--- Auto-indexed foreign key for faster joins
-CREATE INDEX IF NOT EXISTS "Post_authorId_idx"
-  ON "Post"("authorId");
-
--- Partial index for common queries
-CREATE INDEX IF NOT EXISTS "Post_status_active_idx"
-  ON "Post"("status")
-  WHERE "status" = 'active';
-
--- Full-text search index
-CREATE INDEX IF NOT EXISTS "Post_title_search_idx"
-  ON "Post" USING GIN (to_tsvector('english', "title"));
-```
+Schematic reads annotations from Prisma's DMMF `documentation`, validates them with your Zod schemas, and appends the resulting SQL to Prisma migration files.
 
 ---
 
 ## Features
 
-### 🚀 Auto-Optimization (Optional)
+### Pluggable annotation system
 
-- **Automatic FK indexes**: Optionally index all foreign key columns (critical for PostgreSQL performance)
-- **Smart defaults**: Only creates indexes where needed (skips @id, @unique, etc.)
-- **Fully configurable**: Turn features on/off via generator config
+- **You define annotation types** — Zod schema for validation, handler for SQL generation
+- **Core is orchestration only** — extraction, state, diffing, migration appending
+- **No built-in feature assumptions** — partial indexes, GIN indexes, etc. are example handlers, not core logic
 
-### 🎯 Advanced Database Features
+### Prisma-native workflow
 
-- **Partial indexes**: Index subsets of data with `WHERE` clauses
-- **Expression indexes**: Index computed values, full-text search, etc.
-- **Provider-specific types**: GIN, GIST, spatial indexes, and more
-- **Complex constraints**: Check constraints beyond Prisma's limitations
+- Uses Prisma's migration system — no replacement tooling
+- Appends SQL to existing Prisma migration files
+- Production deploys use standard `prisma migrate deploy`
 
-### 🔧 Prisma-Native Workflow
+### Reversible by design
 
-- **Uses Prisma's migration system**: No separate tooling to learn
-- **Modifies Prisma migrations**: Appends SQL to existing migration files
-- **Standard commands**: `prisma migrate deploy` just works
-- **Minimal CLI**: Only adds one command (`enhance`)
+- Each feature stores `upSql` and `downSql` in the state file at creation time
+- Removing an annotation generates the stored `downSql` — **even if the handler is later removed from your config**
+- `schematic enhance` diffs against git HEAD baseline to detect additions and removals
 
-### ✅ Production-Ready
+### Production-ready
 
-- **Idempotent SQL**: Safe to run multiple times (`IF NOT EXISTS`)
-- **Automatic cleanup**: Removes indexes when you delete annotations
-- **Git-friendly**: State file tracks desired features (or use cloud storage)
-- **CI/CD ready**: Validation command for pre-merge checks
-- **No introspection needed**: Simple, fast, provider-agnostic
+- Idempotent SQL (`IF NOT EXISTS`, `IF EXISTS`)
+- Automatic cleanup when annotations are removed
+- Git-friendly state file (commit like `package-lock.json`)
+- CI validation via `schematic validate`
 
 ---
 
@@ -96,182 +74,203 @@ CREATE INDEX IF NOT EXISTS "Post_title_search_idx"
 ### 1. Install
 
 ```bash
-npm install @your-org/schematic --save-dev
+npm install schematic --save-dev
 ```
 
-### 2. Add Generator
+### 2. Define handlers
 
-Add to your `prisma/schema.prisma`:
+Create `schematic.handlers.ts` in your project root:
+
+```typescript
+import { z } from 'zod';
+import type { AnnotationDefinition } from 'schematic';
+
+const partialIndex: AnnotationDefinition = {
+  type: 'partialIndex',
+  schema: z.object({
+    model: z.string(),
+    field: z.string().optional(),
+    columns: z.array(z.string()).min(1),
+    where: z.string(),
+    name: z.string().optional(),
+  }),
+  handlers: {
+    up(input, ctx) {
+      const name =
+        input.name ?? `${ctx.model}_${input.columns.join('_')}_partial_idx`;
+      const cols = input.columns.map((c) => `"${c}"`).join(', ');
+      return {
+        upSql: `CREATE INDEX IF NOT EXISTS "${name}" ON "${ctx.tableName}"(${cols}) WHERE ${input.where};`,
+        downSql: `DROP INDEX IF EXISTS "${name}";`,
+      };
+    },
+  },
+};
+
+export default [partialIndex];
+```
+
+### 3. Configure the generator
+
+Add to `prisma/schema.prisma`:
 
 ```prisma
+generator client {
+  provider = "prisma-client-js"
+}
+
 generator schematic {
-  provider             = "schematic"
-  output               = "../generated"
-  stateFilePath        = "./.schematic-state.json"
-  autoIndexForeignKeys = true  // Recommended for PostgreSQL
+  provider         = "schematic"
+  handlers         = "./schematic.handlers.ts"
+  stateFilePath    = "./.schematic-state.json"
+  annotationPrefix = "schematic"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 ```
 
-### 3. Use in Development
+### 4. Annotate your schema
+
+```prisma
+/// @schematic.partialIndex(columns: ["status"], where: "status = 'active'")
+model Post {
+  id     Int    @id @default(autoincrement())
+  status String
+}
+```
+
+Annotations are doc comments (`///`). Prisma surfaces them on DMMF `model.documentation` and `field.documentation`.
+
+### 5. Development workflow
 
 ```bash
-# Create migration with Prisma
-npx prisma migrate dev --create-only --name add_user_email
+# Create migration with Prisma (don't apply yet)
+npx prisma migrate dev --create-only --name add_post_status_index
 
-# Enhance with Schematic features
+# Append Schematic SQL to the migration
 npx schematic enhance
 
-# Apply with Prisma
+# Apply the combined migration (runs prisma generate, updates state file)
 npx prisma migrate dev
 ```
 
-### 4. Deploy to Production
+**Important:** Run `schematic enhance` before `prisma migrate dev` applies the migration. The state file is updated by `prisma generate`, which runs after migrate — so `enhance` uses the git HEAD state file as its baseline for detecting removals.
+
+### 6. Deploy to production
 
 ```bash
-# Standard Prisma command - just works!
 npx prisma migrate deploy
 ```
 
----
-
-## Usage Examples
-
-### Auto-Index Foreign Keys
-
-**Enable in generator config** to automatically index all foreign key columns:
-
-```prisma
-generator schematic {
-  provider             = "schematic"
-  autoIndexForeignKeys = true  // Enable auto-indexing
-}
-
-model Order {
-  id         Int      @id
-  customerId Int
-  customer   Customer @relation(fields: [customerId], references: [id])
-  // ↑ Schematic adds: CREATE INDEX "Order_customerId_idx" ON "Order"("customerId")
-}
-```
-
-### Partial Indexes
-
-Index only the rows you query frequently:
-
-```prisma
-model User {
-  id     Int     @id
-  email  String  @unique
-  active Boolean @default(true)
-
-  /// @schematic.partialIndex(columns: ["email"], where: "active = true")
-  // ↑ Only indexes active users - smaller, faster index
-}
-```
-
-Generates:
-
-```sql
-CREATE INDEX "User_email_active_idx"
-  ON "User"("email")
-  WHERE "active" = true;
-```
-
-### Full-Text Search (PostgreSQL)
-
-```prisma
-model Article {
-  id      Int    @id
-  title   String
-  content String
-
-  /// @schematic.ginIndex(columns: ["title", "content"], expression: "to_tsvector('english', title || ' ' || content)")
-}
-```
-
-Generates:
-
-```sql
-CREATE INDEX "Article_search_idx"
-  ON "Article" USING GIN (
-    to_tsvector('english', title || ' ' || content)
-  );
-```
-
-### Composite Indexes
-
-```prisma
-model Post {
-  id        Int      @id
-  authorId  Int
-  status    String
-  createdAt DateTime
-
-  /// @schematic.index(columns: ["authorId", "status", "createdAt"])
-  // ↑ Optimized for: WHERE authorId = ? AND status = ? ORDER BY createdAt
-}
-```
+Migration files already contain all SQL. No Schematic CLI needed in production.
 
 ---
 
 ## How It Works
 
-### Architecture
-
 ```
-┌─────────────────────┐
-│   Prisma Schema     │
-└──────────┬──────────┘
-           │
-     ┌─────▼─────┐
-     │  Prisma   │ ──────→ Tables, FKs, basic indexes
-     └─────┬─────┘
-           │
-     ┌─────▼──────┐
-     │ Schematic  │ ──────→ Advanced indexes, constraints
-     └─────┬──────┘
-           │
-     ┌─────▼──────┐
-     │  Database  │
-     └────────────┘
+Prisma Schema (/// @schematic.* doc comments)
+        ↓
+   Prisma DMMF (model.documentation, field.documentation)
+        ↓
+   Schematic extracts & parses annotations
+        ↓
+   Match type → user handler registry
+        ↓
+   Validate with handler's Zod schema
+        ↓
+   handler.up() → upSql + downSql
+        ↓
+   State file (.schematic-state.json)
+        ↓
+   schematic enhance → diff vs git HEAD → append SQL to migration
 ```
 
-### Workflow
+### State file
 
-1. **Generate**: Schematic generator runs during `prisma generate`, creates state file
-2. **Enhance**: `schematic enhance` appends SQL to Prisma's migration file
-3. **Apply**: `prisma migrate` applies the combined migration
-4. **Deploy**: Standard `prisma migrate deploy` in production
-
-### State File
-
-`.schematic-state.json` tracks desired database features:
+`.schematic-state.json` tracks every Schematic-managed feature:
 
 ```json
 {
-	"version": "1.0.0",
-	"schemaHash": "abc123...",
-	"indexes": [
-		{
-			"name": "Post_authorId_idx",
-			"table": "Post",
-			"columns": ["authorId"],
-			"source": "auto-fk-support"
-		}
-	],
-	"partialIndexes": [
-		{
-			"name": "User_email_active_idx",
-			"table": "User",
-			"columns": ["email"],
-			"where": "active = true",
-			"source": "schema-annotation"
-		}
-	]
+  "version": "1",
+  "generatedAt": "2026-07-01T10:00:00.000Z",
+  "schemaHash": "abc123...",
+  "features": [
+    {
+      "id": "a1b2c3...",
+      "type": "partialIndex",
+      "model": "Post",
+      "input": {
+        "columns": ["status"],
+        "where": "status = 'active'"
+      },
+      "upSql": "CREATE INDEX IF NOT EXISTS \"Post_status_partial_idx\" ON \"Post\"(\"status\") WHERE status = 'active';",
+      "downSql": "DROP INDEX IF EXISTS \"Post_status_partial_idx\";",
+      "createdAt": "2026-07-01T10:00:00.000Z"
+    }
+  ]
 }
 ```
 
-**Commit this file to git** - it's like `package-lock.json` for your database enhancements.
+Commit this file to git. It is the source of truth for what Schematic manages and how to reverse it.
+
+---
+
+## Defining Handlers
+
+### `AnnotationDefinition` contract
+
+```typescript
+interface AnnotationDefinition<TSchema extends z.ZodType> {
+  /** Annotation name after @prefix. — e.g. "partialIndex" */
+  type: string;
+
+  /** Zod schema — validates parsed annotation args plus injected context (model, field) */
+  schema: TSchema;
+
+  /** Optional: higher = dropped first when multiple features are removed */
+  dropPriority?: number;
+
+  handlers: {
+    /** Returns SQL pair when a feature is first created */
+    up: (input: z.infer<TSchema>, ctx: HandlerContext) => SqlPair;
+
+    /** Optional: returns SQL pair when args change but identity stays the same */
+    mutate?: (old: z.infer<TSchema>, next: z.infer<TSchema>, ctx: HandlerContext) => SqlPair;
+  };
+}
+
+interface SqlPair {
+  upSql: string;
+  downSql: string;
+}
+
+interface HandlerContext {
+  model: string;
+  field?: string;
+  tableName: string;
+  databaseProvider: string;
+  dmmf: DMMF.Document;
+}
+```
+
+### Handler author guidelines
+
+- Use idempotent SQL (`IF NOT EXISTS` / `IF EXISTS`)
+- Return both `upSql` and `downSql` from `up()` — the `downSql` is persisted in state and used for reversal
+- Set `dropPriority` when your object must drop before others (e.g. constraints before indexes)
+- Avoid cross-feature dependencies where possible
+
+### Example handlers
+
+See [`examples/handlers/`](examples/handlers/) for reference implementations:
+
+- `partial-index.ts` — partial indexes with `WHERE` clauses
+- `gin-index.ts` — PostgreSQL GIN indexes
+- `check-constraint.ts` — check constraints
 
 ---
 
@@ -279,110 +278,76 @@ model Post {
 
 ### `schematic enhance`
 
-Appends Schematic-generated SQL to the most recent Prisma migration.
+Diffs current schema against git HEAD state and appends SQL to the latest Prisma migration.
 
 ```bash
 npx schematic enhance
 ```
 
-**Use after:** `prisma migrate dev --create-only`  
-**Use before:** `prisma migrate dev`
+Run after `prisma migrate dev --create-only` and before `prisma migrate dev`.
+
+**SQL emission order:**
+
+1. Drops (highest `dropPriority` first, then newest-first by `createdAt`)
+2. Creates (stable order by feature `id`)
+3. Mutations (down then up per changed feature)
 
 ### `schematic validate`
 
-Validates state file matches schema (for CI/CD).
+Validates the committed state file matches the current schema. Use in CI.
 
 ```bash
 npx schematic validate
 ```
 
-**Returns:**
-
 - Exit 0 if valid
 - Exit 1 if out of sync (run `prisma generate` to fix)
-
-### `schematic diff` _(coming soon)_
-
-Preview SQL that would be added to migrations.
-
-```bash
-npx schematic diff
-```
-
----
-
-## Annotations Reference
-
-### `@schematic.partialIndex`
-
-Create index with `WHERE` clause:
-
-```prisma
-/// @schematic.partialIndex(columns: ["status"], where: "status IN ('active', 'pending')")
-```
-
-### `@schematic.ginIndex`
-
-PostgreSQL GIN index (full-text, arrays, JSONB):
-
-```prisma
-/// @schematic.ginIndex(columns: ["tags"], expression: "tags")
-```
-
-### `@schematic.index`
-
-Standard index (when you need more control):
-
-```prisma
-/// @schematic.index(columns: ["userId", "createdAt"], type: "btree")
-```
-
-### `@schematic.check`
-
-Complex check constraints:
-
-```prisma
-/// @schematic.check(name: "valid_price", expression: "price > 0 AND price < 1000000")
-```
 
 ---
 
 ## Configuration
 
-Configure in your `schema.prisma`:
-
 ```prisma
 generator schematic {
-  provider      = "schematic"
-  output        = "../generated"
-  stateFilePath = "./.schematic-state.json"
-
-  // Auto-optimization settings (all optional)
-  autoIndexForeignKeys = true   // Automatically index FK columns (default: true, recommended for PostgreSQL)
-
-  // Customization
-  annotationPrefix     = "schematic"  // Custom annotation prefix (default: "schematic")
+  provider         = "schematic"
+  handlers         = "./schematic.handlers.ts"
+  stateFilePath    = "./.schematic-state.json"
+  annotationPrefix = "schematic"
 }
 ```
 
-### Configuration Options
-
-| Option                 | Type    | Default                     | Description                                       |
-| ---------------------- | ------- | --------------------------- | ------------------------------------------------- |
-| `provider`             | string  | required                    | Package name or path to generator                 |
-| `output`               | string  | `"../generated"`            | Output directory for state file                   |
-| `stateFilePath`        | string  | `"./.schematic-state.json"` | Path to state file (relative to schema)           |
-| `autoIndexForeignKeys` | boolean | `true`                      | Auto-create indexes for FK columns                |
-| `annotationPrefix`     | string  | `"schematic"`               | Custom prefix for annotations (@prefix, @@prefix) |
+| Option             | Type   | Default                     | Description                                      |
+| ------------------ | ------ | --------------------------- | ------------------------------------------------ |
+| `provider`         | string | required                    | `"schematic"` or path to generator               |
+| `handlers`         | string | required                    | Path to module exporting `AnnotationDefinition[]` |
+| `stateFilePath`    | string | `"./.schematic-state.json"` | State file path (relative to schema)             |
+| `annotationPrefix` | string | `"schematic"`               | Prefix for `@prefix.type(...)` annotations       |
 
 ---
 
-## CI/CD Setup
+## Reversal
 
-### GitHub Actions
+### Removing an annotation from the schema
+
+1. Delete the `/// @schematic.*` doc comment
+2. Create a Prisma migration (`--create-only`)
+3. Run `schematic enhance` — emits the stored `downSql` from git HEAD state
+4. Run `prisma migrate dev` to apply
+
+### Removing a handler from your config
+
+Already-applied features can still be reversed — their `downSql` is stored in the committed state file. If an annotation remains in the schema but its handler is removed, Schematic fails fast with a clear error at validation time.
+
+### Handler logic changes
+
+Unchanged features (same stable `id`) keep their stored SQL pairs — migrations are immutable history. Changed inputs produce a new `id`, treated as remove old + add new.
+
+---
+
+## CI/CD
 
 ```yaml
-name: Validate Migrations
+name: Validate Schematic
 
 on: [pull_request]
 
@@ -390,16 +355,10 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Generate Prisma Client and Schematic state
-        run: npx prisma generate
-
-      - name: Validate Schematic state
-        run: npx schematic validate
+      - uses: actions/checkout@v4
+      - run: npm ci
+      - run: npx prisma generate
+      - run: npx schematic validate
 ```
 
 ---
@@ -408,128 +367,47 @@ jobs:
 
 ### Do I need Schematic in production?
 
-**No!** Once migrations are built, they contain all the SQL. Just run standard `prisma migrate deploy`.
+No. Migration files contain all SQL after development. Use `prisma migrate deploy` in production.
 
-Schematic is primarily a development tool.
+### What if I get merge conflicts in the state file?
 
-### What if I get merge conflicts in state file?
-
-Just regenerate it:
+Regenerate it:
 
 ```bash
 npx prisma generate
 ```
 
-The state file is derived from your schema, so regenerating it resolves conflicts.
+The state file is derived from your schema and handlers.
 
-### Does this work with all databases?
+### Does Schematic introspect the database?
 
-Schematic works with all databases Prisma supports. However, some features are provider-specific:
+No. Schematic uses idempotent SQL and state-file diffing. This keeps the architecture simple and provider-agnostic.
 
-- ✅ **Auto-FK-indexes**: All databases
-- ✅ **Partial indexes**: PostgreSQL, SQLite
-- ✅ **GIN/GIST indexes**: PostgreSQL only
-- ✅ **Expression indexes**: PostgreSQL, SQLite
+### What about Prisma drift warnings?
 
-### Can I use this with an existing project?
+Prisma may warn about indexes not declared in your schema. This is expected — Schematic manages them separately via the state file.
 
-**Yes!** Just add the generator and run `prisma generate`. Existing migrations aren't affected.
+### Where do annotations come from?
 
-### What about Prisma's drift detection?
-
-Prisma may warn about indexes not in your schema. This is expected—Schematic manages these separately.
-
-To silence warnings, you can add regular `@@index` to your schema for the same columns (Prisma and Schematic will create the same index).
-
-### What happens when I remove an annotation?
-
-**Automatic cleanup!** Schematic compares the old state with the new schema and generates `DROP` statements.
-
-```prisma
-// Remove this annotation:
-/// @schematic.partialIndex(columns: ["email"], where: "active = true")
-```
-
-Next time you run `schematic enhance`, it automatically adds:
-
-```sql
-DROP INDEX IF EXISTS "User_email_active_idx";
-```
-
-The index is cleanly removed from your database.
-
-### Can I store state in the cloud instead of git?
-
-**Yes! (Coming in Phase 7)** Configure cloud storage:
-
-```prisma
-generator schematic {
-  provider     = "schematic"
-  stateStorage = "gcp"
-  stateBucket  = "my-company-bucket"
-  stateKey     = "project/schematic-state.json"
-}
-```
-
-**Benefits:**
-
-- No merge conflicts
-- Centralized for distributed teams
-- State locking for concurrent operations
-- Cleaner git history
-
-**Supported:**
-
-- ✅ Google Cloud Storage (GCP)
-- 🔜 AWS S3 (future)
-- 🔜 Azure Blob Storage (future)
+Doc comments in `schema.prisma` (`///`). Prisma exposes them on DMMF `documentation` for models and fields. Schematic scans those strings — handlers do not define where annotations live.
 
 ---
 
-## Roadmap
+## Documentation
 
-See [docs/roadmap.md](./docs/roadmap.md) for detailed implementation plan.
-
-**MVP (Phase 1-2):**
-
-- ✅ Auto-index foreign keys (configurable)
-- ✅ State file generation with schema hash
-- ✅ `enhance` command with automatic cleanup
-- ✅ Partial index support
-- ✅ Automatic removal of deleted features
-
-**Future:**
-
-- Expression indexes and GIN/GIST indexes
-- Check constraints and triggers
-- Cloud state storage (GCP, S3, Azure)
-- State locking for concurrent operations
-- Optional introspection/drift detection
-- Visual migration preview
+- [Architecture](docs/architecture.md) — module layout, data flow, design decisions
+- [Roadmap](docs/roadmap.md) — completed features and future work
+- [Handler guide](docs/handlers.md) — detailed handler authoring reference
 
 ---
 
-## Contributing
-
-Contributions welcome! Please see our [contributing guidelines](./CONTRIBUTING.md).
-
-### Development Setup
+## Development
 
 ```bash
-# Clone repo
 git clone https://github.com/your-org/schematic.git
 cd schematic
-
-# Install dependencies
 pnpm install
-
-# Build
 pnpm build
-
-# Watch mode
-pnpm dev
-
-# Test
 pnpm test
 ```
 
@@ -538,15 +416,3 @@ pnpm test
 ## License
 
 ISC
-
----
-
-## Related Projects
-
-- [Prisma](https://www.prisma.io/) - The ORM Schematic extends
-- [Prisma Migrate](https://www.prisma.io/docs/orm/prisma-migrate) - Prisma's migration system
-- [Atlas](https://atlasgo.io/) - Alternative migration tool with advanced features
-
----
-
-**Built with ❤️ to make Prisma even better**

--- a/README.md
+++ b/README.md
@@ -395,9 +395,12 @@ Doc comments in `schema.prisma` (`///`). Prisma exposes them on DMMF `documentat
 
 ## Documentation
 
+- [AGENTS.md](AGENTS.md) — entry point for AI agents (read first)
+- [Implementation status](docs/status.md) — what is built vs documented
 - [Architecture](docs/architecture.md) — module layout, data flow, design decisions
-- [Roadmap](docs/roadmap.md) — completed features and future work
+- [Design reference](docs/plan.md) — canonical architecture spec
 - [Handler guide](docs/handlers.md) — detailed handler authoring reference
+- [Roadmap](docs/roadmap.md) — completed features and future work
 
 ---
 

--- a/docs/agent-rules/README.md
+++ b/docs/agent-rules/README.md
@@ -1,46 +1,27 @@
 # Agent Rules Setup
 
-Cursor reads rules from `.cursor/rules/*.mdc`. Source copies live in this directory as `.md` files (plan mode cannot write `.mdc` directly — copy manually or use Agent mode).
+Cursor rules are **installed** in [`.cursor/rules/`](../.cursor/rules/). Sources live here as `.md` files — edit sources, then sync to `.cursor/rules/*.mdc`.
 
-## Install (one-time per clone)
+## Sync after editing sources
 
-Create `.cursor/rules/schematic-core.mdc` from `schematic-core.md` with frontmatter:
+When you change a file in this directory, update the matching `.mdc`:
 
-```yaml
----
-description: Schematic core design rules
-alwaysApply: true
----
+```bash
+# Example: after editing schematic-core.md, rebuild schematic-core.mdc
+# (prepend YAML frontmatter from .cursor/rules/schematic-core.mdc, then append body from schematic-core.md skipping the Cursor install note line)
 ```
 
-Create `.cursor/rules/schematic-handlers.mdc` from `schematic-handlers.md`:
-
-```yaml
----
-description: Handler authoring rules
-globs: examples/**/*.ts,**/schematic.handlers.ts
-alwaysApply: false
----
-```
-
-Create `.cursor/rules/schematic-state.mdc` from `schematic-state.md`:
-
-```yaml
----
-description: State and migration rules
-globs: src/state/**/*.ts,src/migrations/**/*.ts,src/cli/**/*.ts
-alwaysApply: false
----
-```
+Or copy manually: frontmatter from existing `.mdc` + body from `.md` (skip line 3 install note).
 
 ## Rule files
 
-| Source | Scope | Purpose |
-| ------ | ----- | ------- |
-| `schematic-core.md` | Always apply | Non-negotiable design rules |
-| `schematic-handlers.md` | examples, handlers config | Handler authoring |
-| `schematic-state.md` | state, migrations, cli | State, diff, migrations |
+| Source | Installed | Scope |
+| ------ | --------- | ----- |
+| `schematic-core.md` | `.cursor/rules/schematic-core.mdc` | Always apply |
+| `schematic-handlers.md` | `.cursor/rules/schematic-handlers.mdc` | examples, handlers config |
+| `schematic-state.md` | `.cursor/rules/schematic-state.mdc` | state, migrations, cli |
 
 ## For non-Cursor agents
 
-Read [`AGENTS.md`](../../AGENTS.md) at the repo root — it consolidates the same rules plus doc map and status pointers.
+- [AGENTS.md](../../AGENTS.md) — canonical guide
+- [CLAUDE.md](../../CLAUDE.md) — Claude Code entry point

--- a/docs/agent-rules/README.md
+++ b/docs/agent-rules/README.md
@@ -1,0 +1,46 @@
+# Agent Rules Setup
+
+Cursor reads rules from `.cursor/rules/*.mdc`. Source copies live in this directory as `.md` files (plan mode cannot write `.mdc` directly — copy manually or use Agent mode).
+
+## Install (one-time per clone)
+
+Create `.cursor/rules/schematic-core.mdc` from `schematic-core.md` with frontmatter:
+
+```yaml
+---
+description: Schematic core design rules
+alwaysApply: true
+---
+```
+
+Create `.cursor/rules/schematic-handlers.mdc` from `schematic-handlers.md`:
+
+```yaml
+---
+description: Handler authoring rules
+globs: examples/**/*.ts,**/schematic.handlers.ts
+alwaysApply: false
+---
+```
+
+Create `.cursor/rules/schematic-state.mdc` from `schematic-state.md`:
+
+```yaml
+---
+description: State and migration rules
+globs: src/state/**/*.ts,src/migrations/**/*.ts,src/cli/**/*.ts
+alwaysApply: false
+---
+```
+
+## Rule files
+
+| Source | Scope | Purpose |
+| ------ | ----- | ------- |
+| `schematic-core.md` | Always apply | Non-negotiable design rules |
+| `schematic-handlers.md` | examples, handlers config | Handler authoring |
+| `schematic-state.md` | state, migrations, cli | State, diff, migrations |
+
+## For non-Cursor agents
+
+Read [`AGENTS.md`](../../AGENTS.md) at the repo root — it consolidates the same rules plus doc map and status pointers.

--- a/docs/agent-rules/schematic-core.md
+++ b/docs/agent-rules/schematic-core.md
@@ -1,0 +1,24 @@
+# Schematic Core Rules
+
+> Cursor: copy to `.cursor/rules/schematic-core.mdc` with `alwaysApply: true` frontmatter. See [README.md](./README.md).
+
+Schematic is a pluggable Prisma annotation pipeline. Read `AGENTS.md` and `docs/status.md` before coding.
+
+## Must follow
+
+- **No hard-coded annotation types in core** — features live in user handlers or `examples/handlers/`
+- **Annotations from DMMF `documentation`** — model and field doc comments; not custom per-handler locate functions
+- **Persist `downSql` in state at creation** — reversals use stored SQL, not re-invoked handlers
+- **`enhance` baselines git HEAD state** — not post-generate disk state
+- **Preserve stored SQL for unchanged feature ids** — do not re-call `handler.up()` on unchanged entries
+
+## Code style
+
+- Functional, small files, pure functions
+- Minimal diff scope — no drive-by refactors
+- Match existing naming and import patterns (`@/` aliases)
+
+## Before claiming done
+
+- Update `docs/status.md` with what is actually implemented
+- Do not mark roadmap items complete without code + status update

--- a/docs/agent-rules/schematic-handlers.md
+++ b/docs/agent-rules/schematic-handlers.md
@@ -1,0 +1,31 @@
+# Handler Authoring Rules
+
+> Cursor: copy to `.cursor/rules/schematic-handlers.mdc` with `globs: examples/**/*.ts,**/schematic.handlers.ts`.
+
+Handlers are user-defined. Core only orchestrates. See `docs/handlers.md`.
+
+## AnnotationDefinition contract
+
+```typescript
+interface AnnotationDefinition {
+  type: string;           // matches @schematic.{type}(...)
+  schema: z.ZodType;      // validates parsed args + injected model/field
+  dropPriority?: number;  // higher = dropped first on removal
+  handlers: {
+    up: (input, ctx) => ({ upSql, downSql });
+    mutate?: (old, next, ctx) => ({ upSql, downSql });
+  };
+}
+```
+
+## Handler rules
+
+- Return **both** `upSql` and `downSql` from `up()` — downSql is persisted in state
+- Use idempotent SQL: `IF NOT EXISTS` / `IF EXISTS`
+- Derive deterministic object names from model + input
+- Use `ctx.databaseProvider` for provider-specific syntax
+- Do not put handler logic in `src/state/extractor.ts` or `src/generator/`
+
+## Examples belong in `examples/handlers/`
+
+Not in `src/schemas/`. The closed `src/schemas/index.ts` registry is legacy — remove when implementing registry.

--- a/docs/agent-rules/schematic-state.md
+++ b/docs/agent-rules/schematic-state.md
@@ -1,0 +1,45 @@
+# State & Migration Rules
+
+> Cursor: copy to `.cursor/rules/schematic-state.mdc` with `globs: src/state/**/*.ts,src/migrations/**/*.ts,src/cli/**/*.ts`.
+
+See `docs/plan.md` for data flow. See `docs/status.md` for what exists today.
+
+## State shape (target)
+
+```typescript
+interface State {
+  version: '1';
+  generatedAt: string;
+  schemaHash: string;
+  features: StateFeature[];  // NOT indexes[]
+}
+
+interface StateFeature {
+  id: string;
+  type: string;
+  model: string;
+  input: Record<string, unknown>;
+  upSql: string;
+  downSql: string;  // stored at creation, never recomputed on removal
+  createdAt: string;
+}
+```
+
+## Diff rules
+
+- Match features by stable `id`
+- **Added** → emit `upSql`
+- **Removed** → emit stored `downSql` from baseline (git HEAD)
+- **Changed** → emit `mutate()` or old `downSql` + new `upSql`
+
+## Enhance SQL order
+
+1. Drops: `dropPriority` desc, then `createdAt` desc
+2. Creates: stable order by `id`
+3. Mutations: down then up per feature
+
+## Do not
+
+- Bucket features into hard-coded arrays (`indexes`, `partialIndexes`, etc.)
+- Recompute `downSql` on removal
+- Use disk state as enhance baseline

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,683 +1,360 @@
 # Architecture
 
+## Overview
+
+Schematic is a **pluggable annotation pipeline** for Prisma. Core provides orchestration; users provide Zod schemas and handlers for each annotation type. Nothing feature-specific is hard-coded.
+
+---
+
 ## Quick Reference
 
-### Folder Overview (TL;DR)
+### Folder Overview
 
-| Folder | Purpose | Status |
-|--------|---------|--------|
-| **`generator/`** | Entry point & orchestration. Runs when `prisma generate` executes | ✅ Complete |
-| **`state/`** | Build, load, compare, write internal state from annotations | 🟡 Core done, comparator/writer TODO |
-| **`schemas/`** | Zod validation schemas for annotation types (`@schematic.index`, etc.) | ✅ Index schema complete |
-| **`dialects/`** | Database-specific SQL generation (PostgreSQL, MySQL, SQLite, etc.) | 🔴 TODO |
-| **`types/`** | TypeScript type definitions used throughout codebase | ✅ Complete |
-| **`utils/`** | Reusable helpers (annotation parsing, file ops, hashing) | ✅ Complete |
+| Folder           | Purpose                                                         |
+| ---------------- | --------------------------------------------------------------- |
+| `generator/`     | Prisma generator entry point — runs on `prisma generate`        |
+| `registry/`      | Load and validate user handler modules                          |
+| `state/`         | Extract, build, load, compare, and write state                  |
+| `migrations/`    | Find latest Prisma migration and append Schematic SQL           |
+| `cli/`           | `enhance` and `validate` commands                               |
+| `types/`         | TypeScript types including public `AnnotationDefinition` API    |
+| `utils/`         | Annotation parsing, file ops, hashing                           |
 
-### Data Flow (Current)
+### Data Flow
 
 ```
-Prisma Schema → DMMF → Extract Annotations → Validate with Zod → Build State → (TODO: Write to disk)
+Prisma Schema (/// @schematic.* doc comments)
+        ↓
+   Prisma DMMF (model.documentation, field.documentation)
+        ↓
+   extractFromDmmf() → parseAnnotation()
+        ↓
+   Match _schematic_type → registry handler
+        ↓
+   handler.schema.parse() (Zod)
+        ↓
+   handler.up() → { upSql, downSql }
+        ↓
+   State { features: StateFeature[] }
+        ↓
+   schematic enhance: diff vs git HEAD → append SQL to migration
 ```
 
 ---
 
 ## Design Philosophy
 
-Schematic follows a **functional approach with small, focused files** rather than a class-based builder pattern.
+Schematic follows a **functional approach with small, focused files**.
 
-### Why Functional?
+### Core vs user code
+
+| Responsibility         | Owner        |
+| ---------------------- | ------------ |
+| Parse doc comments     | Schematic    |
+| Validate annotation args | User (Zod) |
+| Generate SQL           | User (handler) |
+| Track state            | Schematic    |
+| Diff and emit migrations | Schematic  |
+
+Handlers do **not** define where annotations come from. Core scans DMMF `documentation` on models and fields.
+
+### Why functional?
 
 This tool is primarily about transformations:
+
 - Schema → State
 - State A → State B (diffing)
-- State → SQL
+- Diff → SQL
 - Annotations → Parsed objects
 
-**Benefits:**
-- ✅ Easier to test (pure functions with clear inputs/outputs)
-- ✅ More composable (pipe transformations together)
-- ✅ Better tree-shaking
-- ✅ Simpler to reason about
-- ✅ Matches the data flow nature of the tool
+Pure functions with clear inputs/outputs are easier to test, compose, and reason about.
 
-### When to Use Classes
-
-Use classes sparingly, only for:
-1. **Storage adapters** (GCP, S3) - they have persistent connections
-2. **Configurable services** - if you need instance-specific configuration
-3. **Complex state machines** - if state transitions become complex
+---
 
 ## Folder Structure
 
 ```
 src/
-├── index.ts                  # Entry point (exports generator)
+├── index.ts                  # Prisma generator entry (generatorHandler)
+├── cli.ts                    # CLI entry (enhance, validate)
 │
 ├── generator/
-│   ├── generate.ts           # Main generator orchestrator
-│   ├── generate.test.ts      # Generator tests
-│   ├── config.ts             # Extract/validate generator config
-│   └── config.test.ts        # Config tests
+│   ├── generate.ts           # Orchestrate state generation on prisma generate
+│   ├── config.ts             # Extract generator config (handlers path, etc.)
+│   └── generate.test.ts
+│
+├── registry/
+│   ├── loader.ts             # Dynamic import of user handlers module
+│   ├── types.ts              # AnnotationDefinition (public API)
+│   └── loader.test.ts
 │
 ├── state/
-│   ├── builder.ts            # Build state from DMMF + annotations
-│   ├── builder.test.ts       # Builder tests
-│   ├── extractor.ts          # Extract annotations from DMMF
-│   ├── comparator.ts         # Compare old vs new state (diff) [TODO]
-│   ├── loader.ts             # Load state from disk
-│   ├── loader.test.ts        # Loader tests
-│   └── writer.ts             # Write state to disk [TODO]
+│   ├── extractor.ts          # Scan DMMF documentation, parse, match handlers
+│   ├── builder.ts            # Build state, merge previous downSql for stable ids
+│   ├── loader.ts             # Load state from disk (null if missing)
+│   ├── git-loader.ts         # Load baseline state from git HEAD
+│   ├── writer.ts             # Write state to disk
+│   ├── comparator.ts         # Diff old vs new state by feature id
+│   └── *.test.ts
 │
-├── schemas/
-│   ├── index.ts              # Export all schemas + SchemaType
-│   ├── base.schema.ts        # Base Zod schema (model field)
-│   └── index.schema.ts       # Index annotation validation
+├── migrations/
+│   ├── appender.ts           # Find latest migration, append SQL block
+│   └── sql-emitter.ts        # Order drops/creates/mutations from diff
 │
-├── dialects/
-│   ├── index.ts              # Export dialect registry
-│   ├── base.dialect.ts       # Base dialect interface
-│   └── cockroachdb.dialect.ts # CockroachDB SQL generation [TODO]
+├── cli/
+│   ├── enhance.ts            # enhance command
+│   └── validate.ts           # validate command
 │
 ├── types/
-│   ├── schematic.types.ts    # Core types (Config, Annotation, etc.)
-│   ├── state.types.ts        # State structure types
-│   └── prisma.types.ts       # Prisma generator types
+│   ├── definition.types.ts   # AnnotationDefinition, SqlPair, HandlerContext
+│   ├── state.types.ts        # State, StateFeature
+│   ├── schematic.types.ts    # SchematicConfig
+│   └── prisma.types.ts       # Generator options
 │
 └── utils/
-    ├── annotation.utils.ts   # Parse @schematic.* annotations
-    ├── annotation.utils.test.ts
-    ├── file.utils.ts         # File system operations
-    ├── file.utils.test.ts
-    ├── hash.ts               # SHA256 hashing for change detection
-    └── hash.test.ts
+    ├── annotation.utils.ts   # parseAnnotation() — JSON-like arg parsing
+    ├── file.utils.ts
+    ├── hash.ts               # Stable id generation
+    └── *.test.ts
+
+examples/
+└── handlers/
+    ├── partial-index.ts
+    ├── gin-index.ts
+    ├── check-constraint.ts
+    └── fk-index.ts
 ```
 
-## Key Principles
+---
 
-### 1. Small, Single-Purpose Files
+## Annotation Extraction
 
-Each file should do one thing well:
+Annotations are doc comments in `schema.prisma`. Prisma exposes them on DMMF:
 
-```typescript
-// state/builder.ts - builds state from schema
-export function buildState(dmmf: DMMF, annotations: Annotation[]): State {}
+- `model.documentation` — for `///` comments above a model
+- `field.documentation` — for `///` comments above a field
 
-// state/comparator.ts - compares states
-export function compareStates(oldState: State, newState: State): StateDiff {}
+Core extraction (`state/extractor.ts`):
 
-// sql/index.sql.ts - generates index SQL
-export function createIndexSQL(index: Index, provider: Provider): string {}
-export function dropIndexSQL(index: Index, provider: Provider): string {}
-```
+1. Walk `dmmf.datamodel.models`
+2. Split `model.documentation` and each `field.documentation` by newline
+3. Filter lines starting with `@${annotationPrefix}.`
+4. Parse with `parseAnnotation()` → `{ _schematic_type, ...args }`
+5. Attach context: `{ model, field?, ...parsed }`
+6. Look up handler in registry by `definition.type === _schematic_type`
+7. Validate with `definition.schema.parse()`
 
-### 2. Composition Over Inheritance
+Unknown annotation types (no registered handler) throw immediately.
 
-```typescript
-// cli/enhance.ts
-import { loadState } from '../state/loader';
-import { buildState } from '../state/builder';
-import { compareStates } from '../state/comparator';
-import { generateSQL } from '../sql/generator';
-import { appendToMigration } from '../migrations/appender';
+`@@` attribute blocks are not supported in v1 — only DMMF `documentation` strings.
 
-export async function enhance() {
-  const oldState = await loadState();
-  const newState = await buildState();
-  const diff = compareStates(oldState, newState);
-  const sql = generateSQL(diff);
-  await appendToMigration(sql);
+---
+
+## Handler Registry
+
+Users export `AnnotationDefinition[]` from a module referenced in generator config:
+
+```prisma
+generator schematic {
+  handlers = "./schematic.handlers.ts"
 }
 ```
 
-### 3. Provider Strategy Pattern
+`registry/loader.ts` dynamically imports this module relative to the schema path. Each definition provides:
 
 ```typescript
-// sql/providers.ts
-export interface SQLProvider {
-  createIndex(index: Index): string;
-  dropIndex(index: Index): string;
-  supportsIfNotExists: boolean;
-  supportsConcurrently: boolean;
+interface AnnotationDefinition<TSchema extends z.ZodType> {
+  type: string;
+  schema: TSchema;
+  dropPriority?: number;
+  handlers: {
+    up: (input, ctx) => SqlPair;
+    mutate?: (old, next, ctx) => SqlPair;
+  };
 }
-
-export const providers: Record<Provider, SQLProvider> = {
-  postgres: new PostgresProvider(),
-  mysql: new MySQLProvider(),
-  sqlite: new SQLiteProvider(),
-};
 ```
 
-### 4. Storage Adapter Pattern
+---
+
+## State Model
 
 ```typescript
-// storage/gcp.ts
-export class GCPStorage implements StorageAdapter {
-  constructor(private config: GCPConfig) {}
-  async load(): Promise<State> {}
-  async save(state: State): Promise<void> {}
+interface State {
+  version: '1';
+  generatedAt: string;
+  schemaHash: string;
+  features: StateFeature[];
 }
 
-// storage/local.ts
-export class LocalStorage implements StorageAdapter {
-  constructor(private config: LocalConfig) {}
-  async load(): Promise<State> {}
-  async save(state: State): Promise<void> {}
+interface StateFeature {
+  id: string;           // hash(type + model + field? + canonicalJson(input))
+  type: string;
+  model: string;
+  field?: string;
+  input: Record<string, unknown>;
+  upSql: string;
+  downSql: string;
+  createdAt: string;
 }
 ```
 
-## Data Flow
+### Key invariants
 
-### Current Implementation: State Generation
+1. **`downSql` is persisted at creation** — never recomputed on removal
+2. **Unchanged features preserve stored SQL** — matched by stable `id`; `up()` is not re-called
+3. **State file is committed to git** — like `package-lock.json` for DB enhancements
 
+---
+
+## Generate Path (`prisma generate`)
+
+`generator/generate.ts`:
+
+1. Load handler registry from config
+2. Load previous state from disk (null on first run)
+3. Extract and validate annotations from DMMF
+4. For each feature:
+   - If `id` exists in previous state with same input → preserve stored `upSql`/`downSql`
+   - Otherwise → call `handler.up()`, store new SQL pair
+5. Write updated state via `state/writer.ts`
+
+Generate does **not** append SQL to migrations. That is the CLI's job.
+
+---
+
+## Enhance Path (`schematic enhance`)
+
+`cli/enhance.ts`:
+
+1. Parse schema and build DMMF
+2. Load **baseline state from git HEAD** (`state/git-loader.ts`) — not current disk file
+3. Build current state (same pipeline as generate)
+4. Diff via `state/comparator.ts`:
+   - **Added** — `id` in current, not in baseline → emit `upSql`
+   - **Removed** — `id` in baseline, not in current → emit stored `downSql` from baseline
+   - **Changed** — same `id`, different input → emit `mutate()` or down + up
+5. Order SQL via `migrations/sql-emitter.ts`:
+   - Drops: `dropPriority` desc, then `createdAt` desc
+   - Creates: stable order by `id`
+   - Mutations: down then up per feature
+6. Append to latest Prisma migration via `migrations/appender.ts`
+
+### Why git HEAD baseline?
+
+Workflow order:
+
+```bash
+prisma migrate dev --create-only   # 1. Prisma migration created
+schematic enhance                  # 2. Schematic SQL appended (baseline = git HEAD)
+prisma migrate dev                 # 3. Applied; prisma generate updates state file
 ```
-Prisma Schema (with @schematic annotations)
-          ↓
-    [Prisma DMMF]
-          ↓
-[generator/config.ts] Extract config from generator options
-          ↓
-[generator/generate.ts] Orchestrate generation
-          ↓
-[state/loader.ts] Load previous state (if exists)
-          ↓
-[state/extractor.ts] Parse annotations from DMMF
-          ↓
-          ├─→ [utils/annotation.utils] Parse @schematic.* strings
-          ├─→ [schemas/] Validate with Zod
-          └─→ Returns: { indexes: [...] }
-          ↓
-[state/builder.ts] Build complete state
-          ├─→ generatedAt: ISO timestamp
-          ├─→ schemaHash: SHA256 of DMMF
-          └─→ indexes: validated annotations
-          ↓
-    State Object { generatedAt, schemaHash, indexes }
-          ↓
-[state/writer.ts] Write to disk [TODO]
-```
 
-### Future: Migration Enhancement Flow
+If enhance used the disk state file after `prisma generate`, removals would lose their stored `downSql` before enhance runs.
 
-```
-[TODO] This flow is planned but not yet implemented:
+---
 
-1. Find Latest Prisma Migration
-    ↓
-2. Load Old State (from disk/git)
-    ↓
-3. Build New State (from DMMF)
-    ↓
-4. [state/comparator.ts] Compare old vs new
-    ↓
-5. [dialects/] Generate database-specific SQL
-    ↓
-6. Append SQL to Prisma migration file
-    ↓
-7. [state/writer.ts] Save new state
-```
+## Reversal
 
-### Detailed Flow Example (Current Implementation)
+| Scenario                         | Behavior                                                |
+| -------------------------------- | ------------------------------------------------------- |
+| Annotation removed from schema   | Enhance emits stored `downSql` from git HEAD baseline   |
+| Handler removed from config      | Already-applied features still reversible via state     |
+| Annotation in schema, no handler | Fail fast at validation                                 |
+| Handler logic changed            | Unchanged `id` keeps stored SQL; new input = new `id`   |
 
-```typescript
-// Actual implementation in generator/generate.ts
-export async function generate(options: GeneratorOptions) {
-  // 1. Extract config from generator options
-  const config = extractConfig(options);
-  const { dmmf } = options;
-  
-  // 2. Load previous state (for future comparison)
-  const previousState = await loadState(config.stateFilePath);
-  logger.info('Previous state loaded:', previousState);
-  
-  // 3. Build new state
-  //    ├─ Extract annotations from DMMF
-  //    ├─ Validate with Zod schemas
-  //    └─ Combine with metadata
-  const currentState = buildState(dmmf, config);
-  logger.info('Current state built:', currentState);
-  
-  // 4. Ensure output directory exists
-  await ensureDirectoryExists(config.outputPath);
-  
-  // TODO: Compare states (comparator.ts)
-  // TODO: Generate SQL (dialects/)
-  // TODO: Write migration files
-  // TODO: Save new state (writer.ts)
-}
-```
+---
 
 ## Module Responsibilities
 
-### `generator/` - Core Generator Logic
-**Purpose:** Entry point and orchestration for the Prisma generator
+### `generator/`
 
-- **`generate.ts`** - Main generation function that coordinates:
-  - Config extraction
-  - State building (via builder)
-  - State loading (for comparison)
-  - Output directory creation
-- **`config.ts`** - Extracts and validates configuration from Prisma generator options:
-  - `databaseProvider` (from datasource)
-  - `autoIndexForeignKeys` (boolean)
-  - `annotationPrefix` (default: 'schematic')
-  - `stateFilePath` (default: './schematic.state.json')
-  - `outputPath` (default: './generated')
+- **`generate.ts`** — orchestrate state generation on `prisma generate`
+- **`config.ts`** — extract `handlers`, `stateFilePath`, `annotationPrefix`, `databaseProvider`
 
-### `state/` - State Management
-**Purpose:** Build, load, compare, and write the internal state representation
+### `registry/`
 
-- **`builder.ts`** - Builds current state from DMMF:
-  - Generates timestamp (`generatedAt`)
-  - Computes schema hash (`schemaHash`)
-  - Calls `extractor` to get annotations
-  - Returns complete `State` object
-- **`extractor.ts`** - Extracts and validates annotations from DMMF:
-  - Parses model documentation for `@schematic.*` annotations
-  - Validates using Zod schemas
-  - Filters by annotation type (e.g., `index`)
-  - Returns structured data (e.g., `{ indexes: [...] }`)
-- **`loader.ts`** - Loads previously saved state from JSON file:
-  - Reads state file from disk
-  - Handles missing file gracefully
-  - Validates JSON structure
-- **`comparator.ts`** - [TODO] Compares old vs new state to detect changes
-- **`writer.ts`** - [TODO] Writes current state to JSON file
+- **`loader.ts`** — dynamic import of user handlers module
+- **`types.ts`** — public `AnnotationDefinition` API exported from package
 
-### `schemas/` - Zod Validation
-**Purpose:** Validate extracted annotations match expected structure
+### `state/`
 
-- **`base.schema.ts`** - Base Zod schema with common fields:
-  - `model: z.string()` - Model name
-  - Shared by all annotation schemas
-- **`index.schema.ts`** - Validates `@schematic.index` annotations:
-  - `name?: string` - Index name (optional, can be auto-generated)
-  - `fields: string[]` - Array of field names (min 1 required)
-  - `type?: 'id' | 'unique' | 'normal'` - Index type
-  - `where?: string` - SQL condition for partial indexes
-  - Returns validated `Index` type
-- **`index.ts`** - Central export point:
-  - Exports `schemas` object with all validators
-  - Exports `SchemaType` = union of schema keys (e.g., `"index"`)
-  - Used for type safety throughout codebase
+- **`extractor.ts`** — DMMF documentation scan, parse, validate via registry
+- **`builder.ts`** — assemble state, merge previous SQL for stable ids
+- **`loader.ts`** — read state from disk
+- **`git-loader.ts`** — read state from `git show HEAD:path`
+- **`writer.ts`** — write state JSON
+- **`comparator.ts`** — diff by feature `id`
 
-### `dialects/` - Database-Specific SQL Generation
-**Purpose:** Generate database-specific SQL DDL statements
+### `migrations/`
 
-- **`base.dialect.ts`** - [TODO] Base dialect interface/abstract class
-- **`cockroachdb.dialect.ts`** - [TODO] CockroachDB-specific SQL generation
-- **`index.ts`** - Exports dialect registry
+- **`appender.ts`** — find latest migration directory, append Schematic SQL block with separator comments
+- **`sql-emitter.ts`** — convert diff to ordered SQL statements
 
-> **Note:** Different databases have different syntax:
-> - PostgreSQL: `CONCURRENTLY`, GIN/GiST indexes, partial indexes
-> - MySQL: Different index syntax, no partial indexes
-> - SQLite: Limited index features
+### `cli/`
 
-### `types/` - TypeScript Type Definitions
-**Purpose:** Centralized type definitions for the entire codebase
+- **`enhance.ts`** — full enhance pipeline
+- **`validate.ts`** — rebuild state, compare to committed state file
 
-- **`schematic.types.ts`** - Core types:
-  - `SchematicConfig` - Generator configuration
-  - `RawParsedAnnotation` - Annotation before validation (string type)
-  - `ParsedAnnotation` - Validated annotation (SchemaType)
-  - `Annotation` - ParsedAnnotation + model name
-- **`state.types.ts`** - State structure:
-  - `State` - Complete state file structure
-  - `ExtendedIndex` - Enhanced DMMF.Index with extras (e.g., `where`)
-  - `Extractor<T>` - Generic extractor function type
-- **`prisma.types.ts`** - Prisma generator types:
-  - `GeneratorOptions` - Prisma's generator config options
+### `utils/`
 
-### `utils/` - Utility Functions
-**Purpose:** Reusable helper functions used across the codebase
+- **`annotation.utils.ts`** — parse `@prefix.type(args)` strings with JSON-like arg syntax
+- **`hash.ts`** — SHA256 for schema hash and stable feature ids
+- **`file.utils.ts`** — read/write JSON, path resolution
 
-- **`annotation.utils.ts`** - Parse `@schematic.*` annotations:
-  - `parseAnnotation(annotation, prefix)` → `RawParsedAnnotation`
-  - Strips `@prefix.` from annotation
-  - Parses arguments using JSON5-like syntax
-  - Handles strings, numbers, booleans, arrays, objects
-  - Returns `{ _schematic_type, ...args }`
-- **`file.utils.ts`** - File system operations:
-  - `fileExists(path)` → `boolean`
-  - `readJSONFile<T>(path)` → `Promise<T>`
-  - `writeJSONFile(path, data)` → `Promise<void>`
-  - `ensureDirectoryExists(path)` → `Promise<void>`
-- **`hash.ts`** - SHA256 hashing for change detection:
-  - `computeHash(data)` → `string`
-  - Converts objects to stable JSON
-  - Used to detect schema changes
+---
 
 ## Testing Strategy
 
-With this structure, testing is straightforward:
-
 ```typescript
-// Unit tests - pure functions
+// Unit: pure functions
 describe('compareStates', () => {
-  it('detects removed indexes', () => {
-    const oldState = { indexes: [index1, index2] };
-    const newState = { indexes: [index1] };
+  it('detects removed features and preserves downSql', () => {
+    const oldState = { features: [featureWithDownSql] };
+    const newState = { features: [] };
     const diff = compareStates(oldState, newState);
-    expect(diff.removed.indexes).toEqual([index2]);
+    expect(diff.removed[0].downSql).toBe('DROP INDEX IF EXISTS "foo";');
   });
 });
 
-// Integration tests - compose functions
-describe('state building', () => {
-  it('builds complete state from schema', async () => {
-    const dmmf = await loadTestSchema();
-    const state = await buildState(dmmf);
-    expect(state.indexes).toHaveLength(5);
+// Integration: handler → state → diff → SQL
+describe('enhance', () => {
+  it('emits stored downSql when annotation removed and handler deleted', async () => {
+    // baseline state has feature with downSql
+    // current schema has no annotation
+    // registry has no handler for that type
+    // enhance still emits downSql from baseline
   });
 });
 ```
 
-## Implementation Status
+---
 
-### ✅ Completed (Phase 1)
+## Anti-Patterns
 
-1. **Core types** (`types/`) - All basic types defined
-2. **Annotation parsing** (`utils/annotation.utils.ts`) - Parses `@schematic.*` strings
-3. **State building** (`state/builder.ts`) - Builds state from DMMF
-4. **State extraction** (`state/extractor.ts`) - Extracts & validates annotations
-5. **State loading** (`state/loader.ts`) - Loads previous state from disk
-6. **Zod validation** (`schemas/`) - Validates annotation structure
-7. **Generator orchestration** (`generator/generate.ts`) - Main entry point
-8. **Configuration** (`generator/config.ts`) - Extracts generator config
-9. **Utilities** - File ops, hashing, annotation parsing
-10. **Test coverage** - All core modules have comprehensive tests (130 tests)
-
-### 🚧 In Progress / Next Steps (Phase 2)
-
-1. **State comparison** (`state/comparator.ts`) - Diff old vs new state
-2. **State writer** (`state/writer.ts`) - Persist state to disk
-3. **SQL generation** (`dialects/`) - Generate database-specific DDL
-4. **Migration integration** - Append SQL to Prisma migrations
-
-### 🔮 Future (Phase 3+)
-
-1. **Additional annotation types** - Checks, triggers, custom types
-2. **CLI commands** - `schematic validate`, `schematic diff`
-3. **Cloud storage** - GCP, S3, Azure backends
-4. **Advanced features** - Rollback, preview, validation
-
-## Examples
-
-### Example: Complete Flow (Current Implementation)
-
-**1. User writes annotation in Prisma schema:**
-```prisma
-model User {
-  id    Int    @id @default(autoincrement())
-  email String @unique
-  name  String
-  
-  /// @schematic.index(fields: ["email", "name"], where: "name IS NOT NULL")
-  @@index([email, name])
-}
-```
-
-**2. Annotation is extracted (`state/extractor.ts`):**
-```typescript
-// Finds annotation in model documentation
-const annotation = '@schematic.index(fields: ["email", "name"], where: "name IS NOT NULL")';
-
-// Parses annotation (utils/annotation.utils.ts)
-const parsed = parseAnnotation(annotation, 'schematic');
-// → { _schematic_type: "index", fields: ["email", "name"], where: "name IS NOT NULL" }
-
-// Adds model context
-const withModel = { model: "User", ...parsed };
-// → { _schematic_type: "index", model: "User", fields: ["email", "name"], where: "name IS NOT NULL" }
-```
-
-**3. Annotation is validated (`schemas/index.schema.ts`):**
-```typescript
-// Validates with Zod schema
-const validated = IndexSchema.parse(withModel);
-// → { model: "User", fields: ["email", "name"], where: "name IS NOT NULL" }
-// ✅ Throws if invalid fields or structure
-```
-
-**4. State is built (`state/builder.ts`):**
-```typescript
-const state = buildState(dmmf, config);
-// → {
-//   generatedAt: "2026-01-28T08:00:00.000Z",
-//   schemaHash: "76c25371021f96c0...",
-//   indexes: [
-//     { model: "User", fields: ["email", "name"], where: "name IS NOT NULL" }
-//   ]
-// }
-```
-
-**5. State is saved (TODO: `state/writer.ts`):**
-```json
-// Written to ./schematic.state.json
-{
-  "generatedAt": "2026-01-28T08:00:00.000Z",
-  "schemaHash": "76c25371021f96c0...",
-  "indexes": [
-    {
-      "model": "User",
-      "fields": ["email", "name"],
-      "where": "name IS NOT NULL"
-    }
-  ]
-}
-```
-
-### Example: State Builder (Actual Code)
+### Don't hard-code feature types in core
 
 ```typescript
-// state/builder.ts
-import { DMMF } from '@prisma/generator-helper';
-import computeHash from '@/utils/hash';
-import { State } from '@/types/state.types';
-import { SchematicConfig } from '@/types/schematic.types';
-import extract from './extractor';
+// BAD
+if (type === 'partialIndex') { /* special logic */ }
 
-export default function buildState(
-  dmmf: DMMF.Document,
-  config: SchematicConfig
-): State {
-  // Extract annotations from DMMF and validate
-  const extractions = extract(dmmf, config);
-
-  return {
-    generatedAt: new Date().toISOString(),
-    schemaHash: computeHash(dmmf),
-    ...extractions, // Contains: { indexes: [...] }
-  };
-}
+// GOOD
+const handler = registry.get(type);
+handler.schema.parse(input);
+handler.handlers.up(input, ctx);
 ```
 
-```typescript
-// state/extractor.ts
-export default function extract(
-  dmmf: DMMF.Document,
-  config: SchematicConfig
-): Omit<State, 'generatedAt' | 'schemaHash'> {
-  const annotations = getAnnotations(dmmf, config.annotationPrefix);
-  const extractions = [];
-  
-  annotations.forEach((annotation) => {
-    const schemaType = annotation._schematic_type;
-    
-    // Validate annotation type exists
-    if (!(schemaType in schemas)) {
-      throw new Error(`Unknown annotation type: ${schemaType}`);
-    }
+### Don't re-call up() for unchanged features
 
-    // Validate annotation structure with Zod
-    const extraction = schemas[schemaType as SchemaType](annotation as unknown);
-    extractions.push(extraction);
-  });
+Stored SQL pairs are migration history. Preserve them by stable `id`.
 
-  return {
-    indexes: extractions.filter(
-      (extraction) => extraction._schematic_type === 'index'
-    ),
-  };
-}
-```
+### Don't use disk state as enhance baseline
 
-### Example: Annotation Parser (Actual Code)
+Use git HEAD to avoid losing `downSql` before enhance runs.
 
-```typescript
-// utils/annotation.utils.ts
-export function parseAnnotation(
-  annotation: string,
-  annotationPrefix: string
-): RawParsedAnnotation {
-  const cleaned = annotation.trim();
+---
 
-  // Strip @prefix. in one step: '@schematic.partialIndex(...)' → 'partialIndex(...)'
-  const prefixPattern = new RegExp(`^@${annotationPrefix}\\.`);
-  if (!prefixPattern.test(cleaned)) {
-    throw new Error(
-      `Annotation must start with @${annotationPrefix}. Got: ${annotation}`
-    );
-  }
+## Future Considerations
 
-  const withoutPrefix = cleaned.replace(prefixPattern, '');
+See [future.md](./future.md) for planned extensions: cloud state storage, `schematic diff`, introspection, `@@` attribute block support.
 
-  // Extract type and arguments: 'partialIndex(...)' → ['partialIndex', '...']
-  const match = withoutPrefix.match(/^(\w+)(?:\((.*)\))?$/s);
-  if (!match) {
-    throw new Error(`Invalid annotation format: ${annotation}`);
-  }
-
-  const [, type, argsString] = match;
-  const args = argsString ? parseArguments(argsString) : {};
-
-  return {
-    _schematic_type: type,
-    ...args,
-  };
-}
-
-// Parses: 'fields: ["email"], where: "active = true"'
-// Returns: { fields: ["email"], where: "active = true" }
-function parseArguments(argsString: string): Record<string, unknown> {
-  // ... complex parsing logic for JSON5-like syntax ...
-}
-```
-
-### Example: State Loader (Actual Code)
-
-```typescript
-// state/loader.ts
-import { readJSONFile, fileExists } from '@/utils/file.utils';
-import { State } from '@/types/state.types';
-import { logger } from '@prisma/internals';
-
-export default async function loadState(
-  filePath: string
-): Promise<State | null> {
-  try {
-    const exists = await fileExists(filePath);
-    if (!exists) {
-      logger.info(`No state file found at ${filePath}`);
-      return null;
-    }
-
-    const state = await readJSONFile<State>(filePath);
-    logger.info(`Loaded state from ${filePath}:`, state);
-    return state;
-  } catch (error) {
-    logger.error(`Failed to load state from ${filePath}:`, error);
-    throw new Error(`Failed to load state: ${error.message}`);
-  }
-}
-```
-
-```typescript
-// utils/file.utils.ts
-export async function readJSONFile<T>(filePath: string): Promise<T> {
-  const content = await fs.readFile(filePath, 'utf-8');
-  return JSON.parse(content) as T;
-}
-
-export async function fileExists(filePath: string): Promise<boolean> {
-  try {
-    await fs.access(filePath);
-    return true;
-  } catch {
-    return false;
-  }
-}
-```
-
-## Anti-Patterns to Avoid
-
-### ❌ Don't: Monolithic Files
-
-```typescript
-// BAD: One giant file doing everything
-// generator.ts (1000+ lines)
-export async function generate() {
-  // Load state
-  // Parse annotations
-  // Build state
-  // Compare state
-  // Generate SQL
-  // Write files
-  // ...
-}
-```
-
-### ✅ Do: Small, Composable Functions
-
-```typescript
-// GOOD: Small, focused files
-// cli/enhance.ts
-export async function enhance() {
-  const oldState = await loadState();
-  const newState = await buildState();
-  const diff = compareStates(oldState, newState);
-  const sql = generateSQL(diff);
-  await appendToMigration(sql);
-}
-```
-
-### ❌ Don't: Deep Class Hierarchies
-
-```typescript
-// BAD: Complex inheritance
-class BaseGenerator {}
-class IndexGenerator extends BaseGenerator {}
-class PartialIndexGenerator extends IndexGenerator {}
-```
-
-### ✅ Do: Composition with Functions
-
-```typescript
-// GOOD: Compose behavior
-const sql = pipe(
-  buildIndexes,
-  filterPartialIndexes,
-  generateSQL
-)(state);
-```
-
-### ❌ Don't: Stateful Singletons
-
-```typescript
-// BAD: Global mutable state
-export const STATE = { current: null };
-
-export function setState(s) { STATE.current = s; }
-```
-
-### ✅ Do: Pure Functions with Parameters
-
-```typescript
-// GOOD: Explicit dependencies
-export function compareStates(
-  oldState: State,
-  newState: State
-): StateDiff {
-  // Pure function - no side effects
-}
-```
-
+See [handlers.md](./handlers.md) for the handler authoring reference.

--- a/docs/future.md
+++ b/docs/future.md
@@ -1,3 +1,95 @@
-Add ability to provide a map of your own annotation defintions. This package will provide a type that expects an `up`, `down` and `mutate` function so you can handle those scenarios.
+# Future Enhancements
 
-This allows for a lot of flexibility to provide your own handlers.
+The pluggable annotation pipeline, state management, migration enhancement, and CLI are implemented. This document tracks what comes next.
+
+---
+
+## Near-term
+
+### `schematic diff`
+
+Preview SQL that would be appended by `enhance` without modifying migration files.
+
+```bash
+npx schematic diff
+# Prints ordered SQL to stdout
+```
+
+Useful for PR review and debugging handler output.
+
+### `@@` attribute block support
+
+v1 reads annotations from DMMF `documentation` (doc comments). Some users prefer attribute-style syntax:
+
+```prisma
+model Post {
+  status String
+
+  @@schematic.partialIndex(columns: ["status"], where: "status = 'active'")
+}
+```
+
+Investigate whether Prisma exposes these on DMMF in a parseable form. If not, a schema AST parser may be needed.
+
+### Additional example handlers
+
+- Composite indexes with sort order
+- PostgreSQL `CONCURRENTLY` index creation (non-transactional — document constraints)
+- SQLite-specific partial index patterns
+- Multi-column GIN indexes
+
+---
+
+## Medium-term
+
+### Cloud state storage
+
+For distributed teams that want to avoid state file merge conflicts:
+
+```prisma
+generator schematic {
+  provider     = "schematic"
+  handlers     = "./schematic.handlers.ts"
+  stateStorage = "gcp"
+  stateBucket  = "my-company-bucket"
+  stateKey     = "project/schematic-state.json"
+}
+```
+
+Backends: GCP Cloud Storage, AWS S3, Azure Blob Storage.
+
+Benefits: no merge conflicts, state locking, cleaner git history.
+
+Trade-offs: cloud credentials, network dependency, additional cost.
+
+### Optional introspection (`schematic clean`)
+
+Detect orphaned database objects not tracked in state. Requires per-provider system table queries.
+
+Not needed for v1 — idempotent SQL and state diffing cover the common case.
+
+### Developer experience
+
+- VSCode extension for annotation autocomplete based on registered handler types
+- `schematic init` scaffold for `schematic.handlers.ts`
+- Handler testing utilities (mock `HandlerContext`, assert SQL output)
+
+---
+
+## Long-term
+
+- Triggers and stored procedures as example handlers
+- Custom types and domains
+- Web UI for migration preview and state inspection
+- Schema migration history comparison (Schematic state diffs across migrations)
+
+---
+
+## Explicitly out of scope
+
+These are intentionally not planned as core features — implement as handlers if needed:
+
+- Built-in FK auto-indexing (available as example handler in `examples/handlers/fk-index.ts`)
+- Built-in partial index / GIN index types (available as examples)
+- Database introspection as default workflow
+- Wrapping Prisma CLI commands (`schematic migrate dev` etc.)

--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -1,0 +1,204 @@
+# Handler Authoring Guide
+
+Schematic core provides orchestration — extraction, validation, state management, diffing, and migration appending. **All feature logic lives in user-defined handlers.**
+
+---
+
+## Overview
+
+Each annotation type you want to support requires:
+
+1. A **Zod schema** — validates parsed annotation arguments
+2. A **handler** — produces `upSql` and `downSql` for database changes
+3. **Registration** — export from your `schematic.handlers.ts` module
+
+Annotations are written as doc comments in `schema.prisma`:
+
+```prisma
+/// @schematic.partialIndex(columns: ["status"], where: "status = 'active'")
+model Post {
+  status String
+}
+```
+
+Prisma surfaces these on DMMF `model.documentation` (and `field.documentation` for field-level annotations). Schematic core scans those strings — handlers do not define where annotations are found.
+
+---
+
+## The `AnnotationDefinition` Contract
+
+```typescript
+import { z } from 'zod';
+import type { AnnotationDefinition, HandlerContext, SqlPair } from 'schematic';
+
+export const partialIndex: AnnotationDefinition = {
+  type: 'partialIndex',
+
+  schema: z.object({
+    model: z.string(),
+    field: z.string().optional(),
+    columns: z.array(z.string()).min(1),
+    where: z.string(),
+    name: z.string().optional(),
+  }),
+
+  dropPriority: 0,
+
+  handlers: {
+    up(input, ctx: HandlerContext): SqlPair {
+      const name =
+        input.name ?? `${ctx.model}_${input.columns.join('_')}_partial_idx`;
+      const cols = input.columns.map((c) => `"${c}"`).join(', ');
+
+      return {
+        upSql: `CREATE INDEX IF NOT EXISTS "${name}" ON "${ctx.tableName}"(${cols}) WHERE ${input.where};`,
+        downSql: `DROP INDEX IF EXISTS "${name}";`,
+      };
+    },
+
+    mutate(old, next, ctx): SqlPair {
+      // Optional: custom logic when args change but identity is preserved
+      // Default behavior (if omitted): remove old + add new
+      const down = partialIndex.handlers.up(old, ctx).downSql;
+      const up = partialIndex.handlers.up(next, ctx).upSql;
+      return { upSql: up, downSql: down };
+    },
+  },
+};
+```
+
+### `HandlerContext`
+
+| Field              | Description                                      |
+| ------------------ | ------------------------------------------------ |
+| `model`            | Prisma model name                                |
+| `field`            | Field name, if annotation is on a field doc comment |
+| `tableName`        | Database table name (`@@map` / `@map` resolved)  |
+| `databaseProvider` | Datasource provider (`postgresql`, `mysql`, etc.) |
+| `dmmf`             | Full Prisma DMMF document                        |
+
+### `SqlPair`
+
+Both fields are required from `up()`. The `downSql` is **persisted in the state file** and used for reversal — even if you later remove the handler from your config.
+
+---
+
+## Registration
+
+Export an array from the module referenced in your generator config:
+
+```typescript
+// schematic.handlers.ts
+import { partialIndex } from './handlers/partial-index';
+import { ginIndex } from './handlers/gin-index';
+import { checkConstraint } from './handlers/check-constraint';
+
+export default [partialIndex, ginIndex, checkConstraint];
+```
+
+```prisma
+generator schematic {
+  provider  = "schematic"
+  handlers  = "./schematic.handlers.ts"
+}
+```
+
+Schematic loads this module at runtime via dynamic import, resolved relative to your schema file path.
+
+---
+
+## Annotation Syntax
+
+Annotations use the format `@prefix.type(key: value, ...)` in doc comments:
+
+```prisma
+/// @schematic.partialIndex(columns: ["email"], where: "active = true")
+/// @schematic.ginIndex(columns: ["title"], expression: "to_tsvector('english', title)")
+/// @schematic.check(name: "positive_price", expression: "price > 0")
+```
+
+Supported value types in arguments: strings, numbers, booleans, arrays, and nested objects (JSON-like syntax).
+
+The `annotationPrefix` generator option controls the prefix (default: `schematic`).
+
+---
+
+## Stable Feature Identity
+
+Each feature in the state file has a stable `id`:
+
+```
+hash(type + model + field? + canonicalJson(validatedInput))
+```
+
+This identity drives diffing:
+
+| Change                        | Behavior                                      |
+| ----------------------------- | --------------------------------------------- |
+| Same `id` in old and new state | Unchanged — preserve stored SQL pairs         |
+| `id` in new but not old       | Added — emit `upSql`                          |
+| `id` in old but not new       | Removed — emit stored `downSql` from baseline |
+| Same `id`, different input    | Changed — emit `mutate()` or down + up        |
+
+---
+
+## Reversal Guarantees
+
+### Annotation removed from schema
+
+`schematic enhance` compares current schema against **git HEAD** state. Removed features emit their stored `downSql`. The handler does not need to exist anymore.
+
+### Handler removed from config
+
+- Features already in the committed state file: reversible via stored `downSql`
+- Annotations still in schema with no registered handler: **fail fast** with `"Unknown annotation type: foo, no handler registered"`
+
+### Handler logic updated
+
+Features with unchanged `id` keep their original stored SQL pairs. This is intentional — applied migrations are immutable history. To change applied SQL, remove the old annotation and add a new one (or change inputs enough to produce a new `id`).
+
+---
+
+## Delete Ordering
+
+When multiple features are removed in one migration, drops are ordered by:
+
+1. `dropPriority` descending (higher drops first)
+2. `createdAt` descending (newest first)
+
+Set `dropPriority` on your definition when drop order matters:
+
+```typescript
+export const checkConstraint: AnnotationDefinition = {
+  type: 'check',
+  dropPriority: 10, // drop before indexes (priority 0)
+  // ...
+};
+```
+
+Always use idempotent down SQL (`IF EXISTS`) to tolerate ordering edge cases.
+
+---
+
+## Best Practices
+
+1. **Idempotent SQL** — `CREATE INDEX IF NOT EXISTS`, `DROP INDEX IF EXISTS`
+2. **Persistable down SQL** — write `downSql` assuming the feature was applied; it will be stored and reused
+3. **Deterministic naming** — derive object names from model + columns so the same annotation always produces the same name
+4. **Provider checks** — use `ctx.databaseProvider` to emit provider-specific SQL or throw early for unsupported providers
+5. **No cross-feature coupling** — each handler should be self-contained
+
+---
+
+## Example Handlers
+
+Reference implementations live in [`examples/handlers/`](../examples/handlers/):
+
+| Handler            | Annotation type   | Description                    |
+| ------------------ | ----------------- | ------------------------------ |
+| `partial-index.ts` | `partialIndex`    | Indexes with `WHERE` clauses   |
+| `gin-index.ts`     | `ginIndex`        | PostgreSQL GIN indexes         |
+| `check-constraint.ts` | `check`        | `CHECK` constraints            |
+| `fk-index.ts`      | `fkIndex`         | Optional FK column auto-index  |
+
+These are examples, not built into Schematic core. Copy and adapt them for your project.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -141,6 +141,8 @@ Example handlers live in `examples/handlers/`.
 
 ## Related docs
 
+- [AGENTS.md](../AGENTS.md) — entry point for AI agents working in this repo
+- [status.md](./status.md) — what is implemented vs documented
 - [Architecture](./architecture.md) — module layout and implementation details
 - [Handler guide](./handlers.md) — authoring reference for users
 - [Roadmap](./roadmap.md) — completed features and future work

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,0 +1,146 @@
+# Pluggable Annotation Pipeline — Design Reference
+
+This document describes the implemented architecture for Schematic's pluggable annotation system. It serves as the canonical design reference for the codebase.
+
+---
+
+## Goal
+
+Users define annotation types via **Zod schema + handler**. Schematic orchestrates extraction, validation, state tracking, diffing, and migration SQL — nothing feature-specific is hard-coded in core.
+
+**Reversal strategy:** persist exact `downSql` in state when a feature is first created, so removal never requires the handler to still exist.
+
+---
+
+## Core Contract
+
+```typescript
+interface AnnotationDefinition<TSchema extends z.ZodType> {
+  type: string;
+  schema: TSchema;
+  dropPriority?: number;
+  handlers: {
+    up: (input: z.infer<TSchema>, ctx: HandlerContext) => SqlPair;
+    mutate?: (old: z.infer<TSchema>, next: z.infer<TSchema>, ctx: HandlerContext) => SqlPair;
+  };
+}
+
+interface SqlPair { upSql: string; downSql: string }
+
+interface HandlerContext {
+  model: string;
+  field?: string;
+  tableName: string;
+  databaseProvider: string;
+  dmmf: DMMF.Document;
+}
+```
+
+Users export an array from a module referenced in generator config:
+
+```prisma
+generator schematic {
+  provider  = "schematic"
+  handlers  = "./schematic.handlers.ts"
+}
+```
+
+---
+
+## Annotation Extraction
+
+Annotations are doc comments in `schema.prisma`. Prisma exposes them on DMMF `model.documentation` and `field.documentation`.
+
+Core extraction pipeline (single shared function, not per-handler):
+
+1. Walk DMMF `datamodel.models`
+2. Read `model.documentation` and each `field.documentation`
+3. Filter lines starting with `@${annotationPrefix}.`
+4. Parse each line with `parseAnnotation()`
+5. Attach context: `{ model, field?, ...parsed }`
+6. Match `_schematic_type` to registered handler by `definition.type`
+7. Validate with `definition.schema`
+
+Handlers do not define where annotations come from.
+
+---
+
+## State Model
+
+```typescript
+interface State {
+  version: '1';
+  generatedAt: string;
+  schemaHash: string;
+  features: StateFeature[];
+}
+
+interface StateFeature {
+  id: string;
+  type: string;
+  model: string;
+  field?: string;
+  input: Record<string, unknown>;
+  upSql: string;
+  downSql: string;
+  createdAt: string;
+}
+```
+
+Key invariant: `downSql` is written once when the feature first appears and never recomputed on removal.
+
+---
+
+## Data Flow
+
+### `prisma generate`
+
+1. Load registry from handlers config path
+2. Build current state from DMMF
+3. For each validated feature, call `handler.up()` → store `upSql` + `downSql`
+4. Preserve existing SQL for unchanged features (match by `id`)
+5. Write state to disk
+
+### `schematic enhance`
+
+1. Parse schema + DMMF
+2. Baseline state = git HEAD committed state file
+3. Build current state from schema
+4. Diff via comparator
+5. Emit ordered SQL, append to latest migration
+
+**Critical workflow rule:** run `schematic enhance` before `prisma migrate dev` applies the migration.
+
+---
+
+## Reversal
+
+| Case | Behavior |
+| ---- | -------- |
+| Annotation removed | Enhance emits stored `downSql` from git HEAD baseline |
+| Handler removed | Already-applied features reversible via state; unknown types in schema fail fast |
+| Handler logic changed | Unchanged ids preserve stored SQL; changed input = new id = remove + add |
+
+### Delete ordering
+
+Drops sorted by `dropPriority` desc, then `createdAt` desc. Handlers should use idempotent down SQL (`IF EXISTS`).
+
+---
+
+## What is not in core
+
+- Hard-coded annotation types (partialIndex, ginIndex, etc.)
+- Built-in FK auto-indexing
+- Cloud state storage
+- Database introspection
+- `@@` attribute block annotations (v1 uses DMMF documentation only)
+
+Example handlers live in `examples/handlers/`.
+
+---
+
+## Related docs
+
+- [Architecture](./architecture.md) — module layout and implementation details
+- [Handler guide](./handlers.md) — authoring reference for users
+- [Roadmap](./roadmap.md) — completed features and future work

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,21 +2,27 @@
 
 ## Overview
 
-Schematic is a Prisma enhancement tool that adds database-provider-specific features and optimizations that Prisma doesn't natively support. It works alongside Prisma, not as a replacement.
+Schematic extends Prisma with custom database features via a pluggable annotation system. Users define Zod schemas and handlers; core handles extraction, state, diffing, and migration SQL.
 
 **Key principles:**
 
-- Prisma handles core schema (tables, columns, FKs), Schematic handles enhancements (optimized indexes, partial indexes, custom constraints)
-- Use Prisma's built-in tooling for all workflows - don't wrap or replace Prisma commands
-- Minimal CLI surface area - only add commands where absolutely necessary
+- Prisma handles core schema (tables, columns, FKs, basic indexes)
+- Schematic handles user-defined enhancements via annotations and handlers
+- Use Prisma's built-in migration workflow — don't wrap or replace Prisma commands
+- Minimal CLI surface area — `enhance` and `validate` only
+- Nothing feature-specific is hard-coded in core
 
-## Architecture
+---
+
+## Current Architecture
 
 ### Two-Phase Migration System
 
 ```
 ┌─────────────────────────────────────────────┐
 │         Prisma Schema (schema.prisma)       │
+│         + /// @schematic.* doc comments     │
+│         + schematic.handlers.ts             │
 └──────────────┬─────────────────┬────────────┘
                │                 │
          ┌─────▼──────┐    ┌─────▼──────────┐
@@ -29,15 +35,13 @@ Schematic is a Prisma enhancement tool that adds database-provider-specific feat
          │   Files    │    │   Files        │
          └─────┬──────┘    └─────┬──────────┘
                │                 │
-               ▼                 ▼
+               └────────┬────────┘
+                        ▼
          ┌──────────────────────────────────┐
          │         Database                 │
-         │                                  │
-         │ ✅ Tables (Prisma)               │
-         │ ✅ FKs (Prisma)                  │
+         │ ✅ Tables, FKs (Prisma)          │
          │ ✅ Basic indexes (Prisma)        │
-         │ ✅ FK indexes (Schematic)        │
-         │ ✅ Partial indexes (Schematic)   │
+         │ ✅ Custom features (Schematic)   │
          └──────────────────────────────────┘
 ```
 
@@ -46,556 +50,239 @@ Schematic is a Prisma enhancement tool that adds database-provider-specific feat
 #### Prisma Handles
 
 - Tables, columns, data types
-- Primary keys (`@id`, `@@id`)
-- Unique constraints (`@unique`, `@@unique`)
-- Foreign key constraints (via `@relation`)
+- Primary keys, unique constraints, foreign keys
 - Basic indexes from `@@index`
-- Default values (`@default`)
-- Enums
-- Migration history tracking
-- Client generation
+- Enums, defaults, migration history, client generation
 
 #### Schematic Handles
 
-- **Auto-optimizations (configurable):**
-  - Indexes on FK columns (opt-in via config, critical for PostgreSQL)
-  - Composite indexes for common patterns (future)
-- **Features Prisma doesn't support:**
-  - Partial indexes (`WHERE` clauses)
-  - Expression-based indexes
-  - Provider-specific index types (GIN, GIST, etc.)
-  - Complex check constraints
-  - Triggers (future)
-  - Stored procedures (future)
+- Extract `@schematic.*` annotations from DMMF documentation
+- Validate via user-provided Zod schemas
+- Generate SQL via user-provided handlers (`up` / `mutate`)
+- Track desired state in `.schematic-state.json`
+- Diff and append SQL to Prisma migration files
+- Reverse features using stored `downSql`
+
+#### User Handlers Handle
+
+- Annotation-specific validation (Zod schema)
+- SQL generation (`upSql`, `downSql`)
+- Provider-specific syntax (PostgreSQL GIN, partial indexes, etc.)
+
+---
 
 ## Workflow
 
 ### Development
 
 ```bash
-# 1. Developer modifies schema
+# 1. Modify schema and/or handlers
 vim prisma/schema.prisma
+vim schematic.handlers.ts
 
 # 2. Create migration with Prisma
-npx prisma migrate dev --create-only --name add_email
+npx prisma migrate dev --create-only --name add_partial_index
 
 # 3. Enhance migration with Schematic
 npx schematic enhance
 
-# 4. Apply with Prisma
+# 4. Apply with Prisma (updates state file via prisma generate)
 npx prisma migrate dev
 ```
 
-**What each step does:**
+**Step 3 details (`schematic enhance`):**
 
-**Step 1:** Modify your schema as normal
+- Loads baseline state from git HEAD
+- Builds current state from schema + handlers
+- Diffs to detect additions, removals, changes
+- Appends ordered SQL to the latest Prisma migration file
 
-**Step 2:** `prisma migrate dev --create-only`
+**Step 4 details (`prisma migrate dev`):**
 
-- Prisma creates migration file with schema changes
-- Creates: `migrations/20251110_add_email/migration.sql`
-- Migration not yet applied to database
-
-**Step 3:** `schematic enhance`
-
-- Reads `schema.prisma`
-- Finds FK columns needing indexes
-- Parses `@schematic.*` annotations
-- Generates SQL for enhancements
-- **Appends SQL to the migration file created in Step 2**
-
-**Step 4:** `prisma migrate dev`
-
-- Applies the enhanced migration (Prisma + Schematic SQL)
-- Runs `prisma generate` (updates state file)
-- Updates database
-
-**Result:**
-
-```
-migrations/
-  20251110123456_add_email/
-    migration.sql              # Contains BOTH Prisma + Schematic SQL
-```
-
-**Migration file contains:**
-
-```sql
--- AlterTable (Prisma-generated)
-ALTER TABLE "User" ADD COLUMN "email" TEXT;
-
--- ==========================================
--- Schematic enhancements (auto-generated)
--- Do not edit manually
--- ==========================================
-CREATE INDEX IF NOT EXISTS "Post_authorId_idx"
-  ON "Post"("authorId");
-
-CREATE INDEX IF NOT EXISTS "Post_status_active_idx"
-  ON "Post"("status")
-  WHERE "status" = 'active';
-```
+- Applies combined migration (Prisma + Schematic SQL)
+- Runs `prisma generate` → Schematic generator writes updated state file
 
 ### Production Deployment
 
-Since migration files contain both Prisma and Schematic SQL, use standard Prisma commands:
-
 ```bash
 npx prisma migrate deploy
-# Applies all migrations (includes Schematic SQL)
 ```
 
-**No Schematic wrapper needed** - migration files already contain everything.
+Migration files contain all SQL. No Schematic CLI needed in production.
+
+---
 
 ## State File
 
 ### Purpose
 
-`.schematic-state.json` tracks what Schematic should create. It's generated by the Prisma generator and consumed by the CLI.
+`.schematic-state.json` tracks every Schematic-managed feature and its reversal SQL.
 
-### What Goes In State File
-
-✅ **Include (Schematic-managed features):**
-
-- Auto-generated FK indexes
-- Partial indexes from `@schematic.*` annotations
-- Custom constraints
-- DB-specific features
-
-❌ **Don't Include (Prisma-managed features):**
-
-- Table definitions
-- Column definitions
-- Foreign key constraints
-- `@unique` indexes
-- `@@index` indexes
-- Primary keys
-- Enums
-
-### State File Schema
+### Schema
 
 ```json
 {
-	"version": "1.0.0",
-	"generatedAt": "2025-11-10T10:00:00Z",
-	"schemaHash": "abc123def456",
-
-	"indexes": [
-		{
-			"name": "Post_authorId_idx",
-			"table": "Post",
-			"columns": ["authorId"],
-			"type": "btree",
-			"source": "auto-fk-support"
-		}
-	],
-
-	"partialIndexes": [
-		{
-			"name": "Post_status_active_idx",
-			"table": "Post",
-			"columns": ["status"],
-			"where": "status = 'active'",
-			"source": "schema-annotation"
-		}
-	],
-
-	"checkConstraints": [],
-	"triggers": []
+  "version": "1",
+  "generatedAt": "2026-07-01T10:00:00.000Z",
+  "schemaHash": "abc123def456",
+  "features": [
+    {
+      "id": "a1b2c3d4...",
+      "type": "partialIndex",
+      "model": "Post",
+      "input": {
+        "columns": ["status"],
+        "where": "status = 'active'"
+      },
+      "upSql": "CREATE INDEX IF NOT EXISTS \"Post_status_partial_idx\" ON \"Post\"(\"status\") WHERE status = 'active';",
+      "downSql": "DROP INDEX IF EXISTS \"Post_status_partial_idx\";",
+      "createdAt": "2026-07-01T10:00:00.000Z"
+    }
+  ]
 }
 ```
 
-### State File Management
+### Management
 
-- ✅ **Commit to git** (like `package-lock.json`) - recommended for local storage
-- ✅ **Or store in cloud** (GCP, S3, Azure) - useful for distributed teams
-- ✅ **Regenerated on every `prisma generate`**
-- ✅ **Merge conflicts:** Just run `npx prisma generate` to regenerate
-- ✅ **CI validation:** Check hash matches schema
+- Commit to git (recommended) — like `package-lock.json`
+- Regenerated on every `prisma generate`
+- Merge conflicts: run `npx prisma generate` to regenerate
+- CI validation: `npx schematic validate`
 
-### Automatic Removal of Orphaned Features
+### Reversal
 
-When you remove an annotation or disable auto-indexing, Schematic automatically detects it:
+When an annotation is removed, `schematic enhance` emits the stored `downSql` from the git HEAD baseline. This works even if the handler is later removed from config — the state file is the source of truth for undo.
 
-**How it works:**
-
-1. `schematic enhance` loads the **previous state** (from git or cloud storage)
-2. Generates **new state** from current schema
-3. **Compares** old vs new to detect removals
-4. Generates `DROP INDEX` statements for removed features
-5. Appends to migration file
-
-**Example:**
-
-```prisma
-// Before: Had partial index
-/// @schematic.partialIndex(columns: ["status"], where: "status = 'active'")
-
-// After: Removed annotation
-// (deleted)
-```
-
-**Generated migration includes:**
-
-```sql
--- Schematic enhancements
-DROP INDEX IF EXISTS "Post_status_active_idx";
-```
-
-**Previous state is read from:**
-
-- Git history (`git show HEAD:.schematic-state.json`) for local storage
-- Cloud storage API for remote storage
-- Fallback to disk if available
-
-This ensures indexes/constraints are properly cleaned up when you change your schema.
-
-## Schema Annotations
-
-Users can define custom features via comments:
-
-```prisma
-model Post {
-  id       Int     @id @default(autoincrement())
-  authorId Int
-  author   User    @relation(fields: [authorId], references: [id])
-  // ↑ Schematic auto-adds index on authorId
-
-  status   String
-  /// @schematic.partialIndex(columns: ["status"], where: "status = 'active'")
-  // ↑ User explicitly requests partial index
-
-  title    String
-  /// @schematic.ginIndex(columns: ["title"], expression: "to_tsvector('english', title)")
-  // ↑ PostgreSQL full-text search index
-}
-```
+---
 
 ## CLI Commands
 
-Schematic provides minimal CLI commands. Most workflow uses standard Prisma commands.
-
 ### `schematic enhance`
 
-Appends Schematic-generated SQL to the most recent Prisma migration file.
-
-**Usage:**
+Appends Schematic SQL to the most recent Prisma migration file.
 
 ```bash
-# After creating migration with Prisma
-npx prisma migrate dev --create-only --name add_email
-
-# Enhance it with Schematic
 npx schematic enhance
-
-# Apply with Prisma
-npx prisma migrate dev
 ```
 
-**What it does:**
-
-- Finds the most recent migration in `prisma/migrations/`
-- Analyzes schema for FK indexes and `@schematic.*` annotations
-- Generates SQL for enhancements
-- Appends SQL to the migration file
+Run after `prisma migrate dev --create-only` and before `prisma migrate dev`.
 
 ### `schematic validate`
 
-Validates state file matches schema (for CI).
-
-**Usage:**
+Validates committed state file matches current schema.
 
 ```bash
 npx schematic validate
-# Exits 0 if valid, 1 if out of sync
 ```
 
-### `schematic diff` (future)
+---
 
-Preview what SQL would be added to a migration.
+## Completed Features
 
-**Usage:**
+### Phase 1: Core Infrastructure
 
-```bash
-npx schematic diff
-# Shows SQL that would be appended by 'enhance' command
-```
+- [x] Pluggable `AnnotationDefinition` contract (Zod schema + handler)
+- [x] Handler registry with dynamic import from generator config
+- [x] DMMF documentation extraction (model + field)
+- [x] Generic annotation parser (`@prefix.type(args)`)
+- [x] State file generation with schema hash and stable feature ids
+- [x] State file type definitions (`features[]` with stored SQL pairs)
 
-## No Introspection Approach
+### Phase 2: State Management
 
-**Decision:** Schematic does NOT introspect the database.
+- [x] State writer (persist on `prisma generate`)
+- [x] State loader (graceful null on first run)
+- [x] Git HEAD baseline loader for enhance
+- [x] State comparator (diff by feature id: added / removed / changed)
+- [x] Preserve stored `downSql` for unchanged features
 
-### Why No Introspection?
+### Phase 3: Migration Integration
 
-- **Provider complexity:** Each database has different system tables and query syntax
-- **Maintenance burden:** 80% more code for marginal benefit
-- **Simpler architecture:** Just execute idempotent SQL
-- **Standard SQL:** `CREATE INDEX IF NOT EXISTS` works everywhere
+- [x] `schematic enhance` command
+- [x] Find latest Prisma migration file
+- [x] Ordered SQL emission (drops → creates → mutations)
+- [x] Append SQL with separator comments
+- [x] Delete ordering via `dropPriority` and `createdAt`
 
-### What This Means
+### Phase 4: CLI & Validation
 
-✅ **Schematic creates everything that should exist** (idempotent)  
-✅ **Uses `IF NOT EXISTS` for safety**  
-❌ **Doesn't auto-cleanup orphaned indexes** (acceptable trade-off)
+- [x] `schematic validate` command
+- [x] Separate CLI and generator binaries
+- [x] Example handlers (partial index, GIN index, check constraint, FK index)
+- [x] Handler authoring documentation
 
-Orphaned indexes can be manually cleaned if needed. Future enhancement: optional `schematic clean` command with introspection per provider.
+### Phase 5: Documentation
 
-## Git Workflow with Multiple PRs
+- [x] README with pluggable design
+- [x] Architecture documentation
+- [x] Handler authoring guide
+- [x] Workflow and reversal guarantees documented
 
-### Scenario: Two PRs Modifying Schema
+---
 
-```
-main branch
-├── schema.prisma (3 models)
-└── .schematic-state.json (5 indexes)
+## Future Work
 
-PR #1: Add User.email          PR #2: Add Post.status
-├── schema.prisma               ├── schema.prisma
-└── .schematic-state.json       └── .schematic-state.json
-    (6 indexes)                     (7 indexes)
-```
+See [future.md](./future.md) for detailed plans.
 
-### What Happens
+### Near-term
 
-1. **PR #1 merges first** ✅
-2. **PR #2 tries to merge** → Branch out of date
-3. **PR #2 updates branch:**
+- [ ] `schematic diff` — preview SQL without modifying migration files
+- [ ] `@@schematic[...]` attribute block support (if DMMF exposes them)
+- [ ] Field-level annotation examples and edge case tests
 
-   ```bash
-   git pull origin main
-   # Merge conflict in schema.prisma (if same model edited)
-   # Merge conflict in .schematic-state.json
+### Medium-term
 
-   # Resolve schema conflicts manually
-   # Then regenerate state:
-   npx prisma generate
-
-   # State file now has BOTH changes
-   git add .schematic-state.json
-   git commit
-   ```
-
-4. **PR #2 merges** ✅
-
-### Key Points
-
-- Git prevents simultaneous merges (sequential only)
-- State file conflicts = just regenerate
-- State file is derived from schema (source of truth)
-- Similar to resolving `package-lock.json` conflicts
-
-## Safety Considerations
-
-### State File Missing
-
-**Problem:** Without state file, Schematic doesn't know what it manages.
-
-**Safeguards:**
-
-1. ✅ **Commit state file to git** (primary defense)
-2. ✅ **Error if state file missing** (don't operate blind)
-3. ✅ **Never drop unmarked objects** (future: mark managed objects in DB)
-
-### Migration Failures
-
-**Problem:** Schematic migration fails after Prisma succeeds.
-
-**Mitigations:**
-
-- Use idempotent SQL (`IF NOT EXISTS`)
-- Can safely retry: `npx schematic migrate dev`
-- Both migrations in transaction (Prisma applies both)
-- Clear error messages about which step failed
-
-## Implementation Phases
-
-### Phase 1: Core Infrastructure (MVP)
-
-- [ ] State file generation from schema
-- [ ] FK column detection and auto-indexing
-- [ ] Schema hash validation
-- [ ] State file type definitions
-
-### Phase 2: CLI - Enhance Command
-
-- [ ] `schematic enhance` command
-- [ ] Find most recent migration file
-- [ ] Load previous state file (from disk or git)
-- [ ] Generate new state from current schema
-- [ ] Compare old vs new state (detect additions/removals)
-- [ ] Generate SQL for new indexes/constraints (CREATE)
-- [ ] Generate SQL for removed indexes/constraints (DROP)
-- [ ] Append Schematic SQL to migration file
-- [ ] Clear separation comments in migration file
-- [ ] Update state file on disk
-
-### Phase 3: Schema Annotations
-
-- [ ] Parse Prisma schema comments
-- [ ] Support `@schematic.partialIndex(...)`
-- [ ] Support `@schematic.check(...)`
-- [ ] Merge annotations with auto-features
-
-### Phase 4: SQL Generation
-
-- [ ] Generate idempotent index SQL (`IF NOT EXISTS`)
-- [ ] Provider-specific SQL (PostgreSQL, MySQL, SQLite)
-- [ ] Support `CONCURRENTLY` (PostgreSQL)
-- [ ] Constraint SQL generation
-
-### Phase 5: Validation & Tooling
-
-- [ ] `schematic validate` command
-- [ ] CI/CD examples
-- [ ] Error handling and recovery
-- [ ] Comprehensive logging
-
-### Phase 6: Advanced Features
-
-- [ ] `schematic diff` (preview changes)
-- [ ] Expression-based indexes
-- [ ] GIN/GIST indexes (PostgreSQL)
-- [ ] Configurable auto-indexing rules
-- [ ] Check constraints
-
-### Phase 7: Cloud State Storage
-
-- [ ] Support remote state storage
-- [ ] GCP Cloud Storage backend
-- [ ] AWS S3 backend (future)
-- [ ] Azure Blob Storage backend (future)
-- [ ] Configuration for remote state
-- [ ] Fallback to local state if remote unavailable
+- [ ] Cloud state storage (GCP, S3, Azure)
 - [ ] State locking for concurrent operations
+- [ ] Optional `schematic clean` with per-provider introspection
+- [ ] VSCode extension for annotation autocomplete
 
-**Configuration:**
+### Long-term
 
-```prisma
-generator schematic {
-  provider      = "schematic"
-  stateStorage  = "gcp"  // "local" | "gcp" | "s3" | "azure"
-  stateBucket   = "my-bucket-name"
-  stateKey      = "project/schematic-state.json"
-}
-```
+- [ ] Triggers and stored procedures as example handlers
+- [ ] Web UI for migration preview
+- [ ] Schema migration history comparison
 
-### Phase 8: Optional Introspection
-
-- [ ] `schematic clean` command
-- [ ] Per-provider introspection
-- [ ] Orphaned index detection
-- [ ] Drift detection
-
-### Phase 9: Documentation & Polish
-
-- [ ] README with setup guide
-- [ ] Example schemas
-- [ ] Migration guide
-- [ ] Best practices
-- [ ] Troubleshooting guide
+---
 
 ## Technical Decisions
 
-### Why Append to Prisma's Migration File?
+### Why pluggable handlers instead of built-in annotation types?
 
-**Considered:**
+Different projects need different database features. Hard-coding partial indexes, GIN indexes, etc. in core would require maintaining provider-specific logic for every feature. A registry-driven design lets users define exactly what they need.
 
-1. **Append to Prisma's migration file** ✅
-2. Separate `schematic.sql` in same folder
-3. Separate migration folder
+### Why persist downSql in state?
 
-**Chosen:** Append to same migration file because:
+When a handler is removed from config, Schematic still needs to reverse already-applied features. Storing `downSql` at creation time makes the committed state file the authoritative undo record — no handler required at removal time.
 
-- **Official Prisma workflow** for [unsupported features](https://www.prisma.io/docs/orm/prisma-migrate/workflows/unsupported-database-features)
+### Why git HEAD baseline for enhance?
+
+Workflow order is: create migration → enhance → apply (which runs generate). If enhance used the post-generate disk state, removals would lose their stored `downSql` before enhance could emit it.
+
+### Why append to Prisma's migration file?
+
+- Official Prisma workflow for [unsupported features](https://www.prisma.io/docs/orm/prisma-migrate/workflows/unsupported-database-features)
 - Single migration = single transaction = atomicity
-- Clear comments separate Prisma vs Schematic SQL
 - Standard `--create-only` workflow
-- Single migration history entry
-- No duplicate migrations or timing issues
+- No duplicate migration history entries
 
-### Why Commit State File?
+### Why no introspection?
 
-**Alternative:** `.gitignore` the state file
+- 80% less code for marginal benefit in v1
+- Idempotent SQL (`IF NOT EXISTS`) is sufficient
+- State file diffing handles additions and removals
+- Can add optional introspection later (`schematic clean`)
 
-**Chosen:** Commit it (or store in cloud) because:
-
-- Can review changes in PRs
-- Deterministic (same schema = same state)
-- CI can validate
-- No surprises in production
-- Similar to `package-lock.json`
-- Enables automatic removal of orphaned indexes
-
-### Cloud State Storage vs Git
-
-**Local (Git-committed):**
-
-- ✅ Simple - no additional infrastructure
-- ✅ Version history built-in
-- ✅ Works offline
-- ⚠️ State file in every commit
-- ⚠️ Merge conflicts possible
-
-**Cloud (GCP/S3/Azure):**
-
-- ✅ Centralized state for distributed teams
-- ✅ No merge conflicts
-- ✅ State locking for concurrent operations
-- ✅ Keeps git history cleaner
-- ⚠️ Requires cloud credentials
-- ⚠️ Network dependency
-- ⚠️ Additional cost
-
-**Recommendation:** Start with git-committed, add cloud storage later if needed for large teams.
-
-### Why No Introspection Initially?
-
-**Alternative:** Introspect DB and compute diff
-
-**Chosen:** Skip introspection because:
-
-- Much simpler (80% less code)
-- Provider-agnostic
-- Idempotent SQL is sufficient
-- Orphaned indexes rarely problematic
-- Can add later as optional feature
-
-### Why Wrapper Commands?
-
-**Alternative:** Manual two-step process
-
-**Chosen:** Wrapper commands because:
-
-- Better UX (one command)
-- Can't forget to apply Schematic changes
-- All changes in one migration
-- Atomic application
+---
 
 ## Success Metrics
 
-**MVP is successful when:**
+**v1.0 achieved:**
 
-- ✅ Auto-indexes FK columns on PostgreSQL
-- ✅ Generates state file from schema
-- ✅ One command creates + applies migrations
-- ✅ Works with standard Prisma workflow
-- ✅ State file commits cleanly to git
-
-**v1.0 is successful when:**
-
-- ✅ All Phase 1-5 features complete
-- ✅ Supports partial indexes via annotations
-- ✅ Works on PostgreSQL, MySQL, SQLite
-- ✅ Comprehensive documentation
-- ✅ CI validation examples
-
-## Future Enhancements
-
-- Custom validation rules
-- Stored procedures and functions
-- Triggers
-- Custom types
-- Advanced constraint types
-- Schema migration history comparison
-- Web UI for migration preview
-- VSCode extension for annotation autocomplete
+- Users define custom annotation types via Zod + handler
+- Core has zero hard-coded feature logic
+- `prisma generate` writes state file with stored SQL pairs
+- `schematic enhance` diffs and appends migration SQL
+- Removals work via stored `downSql`, even without handler
+- Example handlers cover common PostgreSQL patterns
+- CI validation via `schematic validate`

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,0 +1,105 @@
+# Implementation Status
+
+This document tracks **what is actually implemented in code** vs what the rest of the documentation describes as the target architecture.
+
+**Last updated:** 2026-07-01 (branch: `docs/pluggable-annotation-pipeline`)
+
+When implementing features, update this file in the same PR as the code changes.
+
+---
+
+## Summary
+
+| Area | Documented | Implemented |
+| ---- | ---------- | ----------- |
+| Pluggable handler registry | Yes | No |
+| DMMF documentation extraction | Yes | Partial (model docs only) |
+| Generic `features[]` state | Yes | No (hard-coded `indexes[]`) |
+| Stored `upSql` / `downSql` | Yes | No |
+| State writer | Yes | No |
+| State comparator | Yes | No |
+| Git HEAD baseline loader | Yes | No |
+| `schematic enhance` CLI | Yes | No |
+| `schematic validate` CLI | Yes | No |
+| Example handlers | Yes | No |
+| Reversal without handler | Yes | No |
+
+---
+
+## Implemented (on `main` / early foundation)
+
+- Prisma generator entry point (`src/index.ts`)
+- Generator config extraction (`src/generator/config.ts`)
+- Annotation parser (`src/utils/annotation.utils.ts`) — generic `@prefix.type(args)` parsing
+- DMMF model documentation extraction (`src/state/extractor.ts`) — **model docs only**
+- Closed Zod registry with single `index` type (`src/schemas/`)
+- State builder with `generatedAt`, `schemaHash`, `indexes[]` (`src/state/builder.ts`)
+- State loader from disk (`src/state/loader.ts`) — throws if missing (should return null)
+- File utils, hash utils
+- Unit tests for above modules
+
+## Not implemented (documented as target)
+
+### Registry & handlers
+
+- [ ] `AnnotationDefinition` public API (`src/registry/types.ts`)
+- [ ] Dynamic handler loader from generator `handlers` config (`src/registry/loader.ts`)
+- [ ] Remove closed `src/schemas/index.ts` registry
+- [ ] Move `index.schema.ts` to `examples/handlers/`
+
+### State
+
+- [ ] `State.features[]` replacing `State.indexes[]`
+- [ ] Stable feature `id` generation
+- [ ] Persist `upSql` and `downSql` per feature
+- [ ] Merge previous state to preserve SQL for unchanged ids (`src/state/builder.ts`)
+- [ ] State writer (`src/state/writer.ts`)
+- [ ] Loader returns `null` on missing file (first run)
+- [ ] Field-level documentation scanning in extractor
+
+### Diff & migrations
+
+- [ ] State comparator (`src/state/comparator.ts`)
+- [ ] Git HEAD baseline loader (`src/state/git-loader.ts`)
+- [ ] Migration appender (`src/migrations/appender.ts`)
+- [ ] SQL emitter with drop ordering (`src/migrations/sql-emitter.ts`)
+
+### CLI
+
+- [ ] Separate `dist/cli.js` binary
+- [ ] `schematic enhance` command
+- [ ] `schematic validate` command
+
+### Examples
+
+- [ ] `examples/handlers/partial-index.ts`
+- [ ] `examples/handlers/gin-index.ts`
+- [ ] `examples/handlers/check-constraint.ts`
+- [ ] `examples/handlers/fk-index.ts`
+
+---
+
+## Intentionally not planned (core)
+
+- Hard-coded `partialIndex`, `ginIndex`, `check` in core
+- Built-in `autoIndexForeignKeys` (example handler only)
+- Cloud state storage
+- Database introspection
+- `@@` attribute block annotations (v1)
+
+See [future.md](./future.md).
+
+---
+
+## How to update this file
+
+When completing an item:
+
+1. Move it from "Not implemented" to "Implemented" with the file path
+2. Update the summary table
+3. If docs claimed completion prematurely, no doc change needed once code lands
+
+When partially implementing:
+
+1. Note exactly what works and what doesn't
+2. Don't mark roadmap items complete in [roadmap.md](./roadmap.md) until reflected here


### PR DESCRIPTION
## Summary

- Rewrites README and docs to describe the target pluggable annotation architecture (user-defined Zod schemas + handlers, stored `downSql` reversal, git HEAD enhance baseline).
- Adds agent infrastructure so future AI sessions stay aligned: `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `docs/status.md` (implementation truth), and Cursor rules/skill.
- Adds a PR template with doc/test checklist. Docs describe target design; `docs/status.md` tracks what is actually implemented in code.

## Test plan

- [ ] Review doc hierarchy: AGENTS.md → status.md → plan.md
- [ ] Confirm Cursor rules load in `.cursor/rules/`
- [ ] Verify no code changes (docs-only PR)

Made with [Cursor](https://cursor.com)